### PR TITLE
operator: ingress reconciler update resource and status

### DIFF
--- a/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
+++ b/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: kroxylicious
     app.kubernetes.io/component: operator
 rules:
-  - # The operator needs to know about its own CRs
+  - # The operator needs to know about its own CRs, and patch them with annotations
     apiGroups:
       - "kroxylicious.io"
     resources:
@@ -26,6 +26,7 @@ rules:
       - get
       - list
       - watch
+      - patch
   - # The operator needs to update the status on its own CRs
     apiGroups:
       - "kroxylicious.io"

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconciler.java
@@ -88,7 +88,7 @@ public class KafkaProxyIngressReconciler implements
         if (LOGGER.isInfoEnabled()) {
             LOGGER.info("Completed reconciliation of {}/{}", namespace(ingress), name(ingress));
         }
-        return UpdateControl.patchStatus(patch);
+        return UpdateControl.patchResourceAndStatus(patch);
     }
 
     @Override

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconcilerIT.java
@@ -26,6 +26,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
 import io.kroxylicious.kubernetes.operator.assertj.KafkaProxyIngressStatusAssert;
+import io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator;
 
 import static io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.ClusterIP.Protocol.TCP;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -121,6 +122,11 @@ class KafkaProxyIngressReconcilerIT {
                     .conditionList()
                     .singleElement()
                     .isResolvedRefsTrue(kpi);
+        });
+        AWAIT.alias("referent checksum annotation present").untilAsserted(() -> {
+            var kpi = testActor.resources(KafkaProxyIngress.class)
+                    .withName(ResourcesUtil.name(ingressBar)).get();
+            assertThat(kpi.getMetadata().getAnnotations()).isNotNull().containsKey(MetadataChecksumGenerator.REFERENT_CHECKSUM_ANNOTATION);
         });
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconcilerTest.java
@@ -83,7 +83,7 @@ class KafkaProxyIngressReconcilerTest {
 
         // then
         assertThat(update).isNotNull();
-        assertThat(update.isPatchStatus()).isTrue();
+        assertThat(update.isPatchResourceAndStatus()).isTrue();
         assertThat(update.getResource()).isPresent();
         assertThat(update.getResource().get().getStatus())
                 .hasObservedGenerationInSyncWithMetadataOf(INGRESS)
@@ -106,7 +106,7 @@ class KafkaProxyIngressReconcilerTest {
 
         // then
         assertThat(update).isNotNull();
-        assertThat(update.isPatchStatus()).isTrue();
+        assertThat(update.isPatchResourceAndStatus()).isTrue();
         assertThat(update.getResource()).isPresent();
         KafkaProxyIngressStatusAssert.assertThat(update.getResource().get().getStatus())
                 .hasObservedGenerationInSyncWithMetadataOf(INGRESS)
@@ -130,13 +130,16 @@ class KafkaProxyIngressReconcilerTest {
         // then
         assertThat(update)
                 .isNotNull()
-                .satisfies(uc -> Assertions.assertThat(update.getResource())
-                        .isPresent()
-                        .satisfies(kpi -> OperatorAssertions.assertThat(kpi.get())
-                                .hasAnnotationSatisfying(MetadataChecksumGenerator.REFERENT_CHECKSUM_ANNOTATION,
-                                        actualValue -> Assertions.assertThat(actualValue)
-                                                .isNotBlank()
-                                                .isBase64())));
+                .satisfies(uc -> {
+                    assertThat(update.isPatchResourceAndStatus()).isTrue();
+                    Assertions.assertThat(update.getResource())
+                            .isPresent()
+                            .satisfies(kpi -> OperatorAssertions.assertThat(kpi.get())
+                                    .hasAnnotationSatisfying(MetadataChecksumGenerator.REFERENT_CHECKSUM_ANNOTATION,
+                                            actualValue -> Assertions.assertThat(actualValue)
+                                                    .isNotBlank()
+                                                    .isBase64()));
+                });
 
     }
 
@@ -163,6 +166,7 @@ class KafkaProxyIngressReconcilerTest {
                 .isNotNull()
                 .satisfies(uc -> {
                     Assertions.assertThat(update.getResource()).isPresent();
+                    Assertions.assertThat(update.isPatchResourceAndStatus()).isTrue();
                     Assertions.assertThat(update.getResource().get()).satisfies(kpi -> OperatorAssertions.assertThat(kpi)
                             .hasAnnotationSatisfying(MetadataChecksumGenerator.REFERENT_CHECKSUM_ANNOTATION,
                                     actualValue -> Assertions.assertThat(actualValue)


### PR DESCRIPTION
- give the operator permissions to patch the watched CRs
- patch resource and status of kafkaproxyingress

We now want to add an annotation to the resource itself as an output of reconciliation. The operator needs permission to patch the resource.