### PR TITLE
Test v0 ApiVersions forwarding with IT

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/Request.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/Request.java
@@ -12,6 +12,12 @@ import org.apache.kafka.common.protocol.ApiMessage;
 public record Request(ApiKeys apiKeys,
                       short apiVersion,
                       String clientIdHeader,
-                      ApiMessage message) {
-
+                      ApiMessage message,
+                      short responseApiVersion) {
+    public Request(ApiKeys apiKeys,
+                   short apiVersion,
+                   String clientIdHeader,
+                   ApiMessage message) {
+        this(apiKeys, apiVersion, clientIdHeader, message, apiVersion);
+    }
 }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/CorrelationManager.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/CorrelationManager.java
@@ -33,15 +33,16 @@ public class CorrelationManager {
     /**
      * Allocate and return a correlation id for an outgoing request to the broker.
      *
-     * @param apiKey         The API key.
-     * @param apiVersion     The API version.
-     * @param correlationId  The request's correlation id.
+     * @param apiKey The API key.
+     * @param apiVersion The API version.
+     * @param correlationId The request's correlation id.
      * @param responseFuture The future to complete with the response
+     * @param responseApiVersion
      */
     public void putBrokerRequest(short apiKey,
                                  short apiVersion,
-                                 int correlationId, CompletableFuture<SequencedResponse> responseFuture) {
-        Correlation existing = this.brokerRequests.put(correlationId, new Correlation(apiKey, apiVersion, responseFuture));
+                                 int correlationId, CompletableFuture<SequencedResponse> responseFuture, short responseApiVersion) {
+        Correlation existing = this.brokerRequests.put(correlationId, new Correlation(apiKey, apiVersion, responseFuture, responseApiVersion));
         if (existing != null) {
             LOGGER.error("Duplicate upstream correlation id {}", correlationId);
         }
@@ -72,13 +73,15 @@ public class CorrelationManager {
      */
     public record Correlation(short apiKey,
                               short apiVersion,
-                              CompletableFuture<SequencedResponse> responseFuture) {
+                              CompletableFuture<SequencedResponse> responseFuture,
+                              short responseApiVersion) {
 
         @Override
         public String toString() {
             return "Correlation(" +
                     "apiKey=" + ApiKeys.forId(apiKey) +
                     ", apiVersion=" + apiVersion +
+                    ", responseApiVersion=" + responseApiVersion +
                     ')';
         }
 
@@ -91,12 +94,12 @@ public class CorrelationManager {
                 return false;
             }
             Correlation that = (Correlation) o;
-            return apiKey == that.apiKey && apiVersion == that.apiVersion;
+            return apiKey == that.apiKey && apiVersion == that.apiVersion && responseApiVersion == that.responseApiVersion;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(apiKey, apiVersion);
+            return Objects.hash(apiKey, apiVersion, responseApiVersion);
         }
 
     }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClient.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClient.java
@@ -93,7 +93,7 @@ public final class KafkaClient implements AutoCloseable {
         var header = new RequestHeaderData().setRequestApiKey(messageType.apiKey()).setRequestApiVersion(request.apiVersion());
         header.setClientId(request.clientIdHeader());
         header.setCorrelationId(correlationId.incrementAndGet());
-        return new DecodedRequestFrame<>(header.requestApiVersion(), header.correlationId(), header, request.message());
+        return new DecodedRequestFrame<>(header.requestApiVersion(), header.correlationId(), header, request.message(), request.responseApiVersion());
     }
 
     // TODO return a Response class with jsonObject() and frame() methods

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/DecodedRequestFrame.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/DecodedRequestFrame.java
@@ -22,19 +22,24 @@ public class DecodedRequestFrame<B extends ApiMessage>
         implements RequestFrame {
 
     private final CompletableFuture<SequencedResponse> responseFuture = new CompletableFuture<>();
+    private final short responseApiVersion;
 
     /**
      * Create a decoded request frame
+     *
      * @param apiVersion apiVersion
      * @param correlationId correlationId
      * @param header header
      * @param body body
+     * @param responseApiVersion
      */
     public DecodedRequestFrame(short apiVersion,
                                int correlationId,
                                RequestHeaderData header,
-                               B body) {
+                               B body,
+                               short responseApiVersion) {
         super(apiVersion, correlationId, header, body);
+        this.responseApiVersion = responseApiVersion;
     }
 
     @Override
@@ -53,5 +58,10 @@ public class DecodedRequestFrame<B extends ApiMessage>
     @Override
     public boolean hasResponse() {
         return !(body instanceof ProduceRequest pr && pr.acks() == 0);
+    }
+
+    @Override
+    public short responseApiVersion() {
+        return responseApiVersion;
     }
 }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestDecoder.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestDecoder.java
@@ -71,7 +71,7 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
             log().trace("{}: body {}", ctx, body);
         }
 
-        frame = new DecodedRequestFrame<>(apiVersion, correlationId, header, body);
+        frame = new DecodedRequestFrame<>(apiVersion, correlationId, header, body, apiVersion);
         if (log().isTraceEnabled()) {
             log().trace("{}: frame {}", ctx, frame);
         }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestEncoder.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestEncoder.java
@@ -39,7 +39,7 @@ public class KafkaRequestEncoder extends KafkaMessageEncoder<RequestFrame> {
     protected void encode(ChannelHandlerContext ctx, RequestFrame frame, ByteBuf out) throws Exception {
         super.encode(ctx, frame, out);
         if (frame.hasResponse()) {
-            correlationManager.putBrokerRequest(frame.apiKey().id, frame.apiVersion(), frame.correlationId(), frame.getResponseFuture());
+            correlationManager.putBrokerRequest(frame.apiKey().id, frame.apiVersion(), frame.correlationId(), frame.getResponseFuture(), frame.responseApiVersion());
         }
     }
 

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaResponseDecoder.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaResponseDecoder.java
@@ -67,6 +67,9 @@ public class KafkaResponseDecoder extends KafkaMessageDecoder {
             ApiMessage body = BodyDecoder.decodeResponse(apiKey, apiVersion, accessor);
             log().trace("{}: Body: {}", ctx, body);
             frame = new DecodedResponseFrame<>(apiVersion, correlationId, header, body);
+            if (in.readableBytes() != 0) {
+                throw new RuntimeException("Unread bytes remaining in frame, potentially response api version differs from expectation");
+            }
             correlation.responseFuture().complete(new SequencedResponse(frame, i++));
             return frame;
         }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/RequestFrame.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/RequestFrame.java
@@ -36,4 +36,8 @@ public interface RequestFrame extends Frame {
      */
     short apiVersion();
 
+    default short responseApiVersion() {
+        return apiVersion();
+    }
+
 }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockHandler.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockHandler.java
@@ -25,6 +25,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 
 import io.kroxylicious.test.Request;
+import io.kroxylicious.test.ResponsePayload;
 import io.kroxylicious.test.codec.DecodedRequestFrame;
 
 /**
@@ -51,11 +52,12 @@ public class MockHandler extends ChannelInboundHandlerAdapter {
 
     /**
      * Create mockhandler with initial message to serve
-     * @param message message to respond with, nullable
+     * @param payload payload to respond with, nullable
      */
-    public MockHandler(ApiMessage message) {
-        if (message != null) {
-            setMockResponseForApiKey(ApiKeys.forId(message.apiKey()), message);
+    public MockHandler(ResponsePayload payload) {
+        if (payload != null && payload.message() != null) {
+            ApiMessage message = payload.message();
+            setMockResponseForApiKey(ApiKeys.forId(message.apiKey()), message, payload.responseApiVersion());
         }
     }
 

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockServer.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockServer.java
@@ -125,7 +125,7 @@ public final class MockServer implements AutoCloseable {
         final EventGroupConfig eventGroupConfig = EventGroupConfig.create();
         bossGroup = eventGroupConfig.newBossGroup();
         workerGroup = eventGroupConfig.newWorkerGroup();
-        serverHandler = new MockHandler(response == null ? null : response.message());
+        serverHandler = new MockHandler(response);
         ServerBootstrap b = new ServerBootstrap();
         b.group(bossGroup, workerGroup)
                 .channel(eventGroupConfig.serverChannelClass())

--- a/kroxylicious-integration-test-support/src/main/templates/BodyDecoder.ftl
+++ b/kroxylicious-integration-test-support/src/main/templates/BodyDecoder.ftl
@@ -73,27 +73,7 @@ public class BodyDecoder {
         return switch (apiKey) {
 <#list messageSpecs as messageSpec>
     <#if messageSpec.type?lower_case == 'response'>
-        <#if messageSpec.name == 'ApiVersionsResponse'>
-            case ${retrieveApiKey(messageSpec)} -> {
-                // KIP-511 when the client receives an unsupported version for the ApiVersionResponse, it fails back to version 0
-                // Use the same algorithm as https://github.com/apache/kafka/blob/a41c10fd49841381b5207c184a385622094ed440/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java#L90-L106
-                int prev = accessor.readerIndex();
-                try {
-                    yield new ${messageSpec.name}Data(accessor, apiVersion);
-                }
-                catch (RuntimeException e) {
-                    accessor.readerIndex(prev);
-                    if (apiVersion != 0) {
-                        yield new ${messageSpec.name}Data(accessor, (short) 0);
-                    }
-                    else {
-                        throw e;
-                    }
-                }
-            }
-        <#else>
-            case ${retrieveApiKey(messageSpec)} -> new ${messageSpec.name}Data(accessor, apiVersion);
-        </#if>
+        case ${retrieveApiKey(messageSpec)} -> new ${messageSpec.name}Data(accessor, apiVersion);
     </#if>
 </#list>
             default -> throw new IllegalArgumentException("Unsupported RPC " + apiKey);

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/client/CorrelationManagerTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/client/CorrelationManagerTest.java
@@ -21,8 +21,8 @@ class CorrelationManagerTest {
         CorrelationManager correlationManager = new CorrelationManager();
         CompletableFuture<SequencedResponse> responseFuture = new CompletableFuture<>();
         CompletableFuture<SequencedResponse> responseFuture2 = new CompletableFuture<>();
-        correlationManager.putBrokerRequest((short) 1, (short) 1, 1, responseFuture);
-        correlationManager.putBrokerRequest((short) 1, (short) 1, 2, responseFuture2);
+        correlationManager.putBrokerRequest((short) 1, (short) 1, 1, responseFuture, (short) 1);
+        correlationManager.putBrokerRequest((short) 1, (short) 1, 2, responseFuture2, (short) 1);
 
         // when
         correlationManager.onChannelClose();
@@ -37,8 +37,8 @@ class CorrelationManagerTest {
         // given
         CorrelationManager correlationManager = new CorrelationManager();
         CompletableFuture<SequencedResponse> responseFuture = new CompletableFuture<>();
-        correlationManager.putBrokerRequest((short) 1, (short) 1, 1, responseFuture);
-        correlationManager.putBrokerRequest((short) 1, (short) 1, 2, null);
+        correlationManager.putBrokerRequest((short) 1, (short) 1, 1, responseFuture, (short) 1);
+        correlationManager.putBrokerRequest((short) 1, (short) 1, 2, null, (short) 1);
 
         // when
         correlationManager.onChannelClose();
@@ -53,7 +53,7 @@ class CorrelationManagerTest {
         int correlationId = 1;
         CorrelationManager correlationManager = new CorrelationManager();
         CompletableFuture<SequencedResponse> responseFuture = new CompletableFuture<>();
-        correlationManager.putBrokerRequest((short) 1, (short) 1, correlationId, responseFuture);
+        correlationManager.putBrokerRequest((short) 1, (short) 1, correlationId, responseFuture, (short) 1);
         CorrelationManager.Correlation brokerCorrelation = correlationManager.getBrokerCorrelation(correlationId);
         assertThat(brokerCorrelation).isNotNull();
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Test ApiVersions v0 upstream response is forwarded
    
* Makes the test KafkaClient less smart, it must be told the expected response apiVersion, rather than implementing a fallback if it cannot understand the response. This means that our test that expects to successfully decode
  a v0 ApiVersions response would fail if it received a message encoded with another apiVersion.
* Fixed the MockServer constructor, it wasn't wiring up the response apiVersion correctly.
* Fixed a problem where an error at decode time in the test client resulted in a timeout. If we've obtained a correlation, then we can complete the response future exceptionally. This makes the test fail faster if the message can't be decoded at the expected version.
* Adds coverage to the production KafkaResponseDecoder that sonar is upset about

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
