### PR TITLE
refactor(operator): introduce ClusterUser to make actor-vs-SUT boundary explicit

### DIFF
--- a/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/kubernetes/operator/ClusterUser.java
+++ b/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/kubernetes/operator/ClusterUser.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Represents a cluster user interacting with Kubernetes resources in a specific namespace.
+ * <p>
+ * This is distinct from the operator's own client: a {@code ClusterUser} holds a
+ * Kubernetes client scoped to the RBAC of a regular user, not the operator itself.
+ * Using this explicitly in tests makes clear which operations represent user actions
+ * and which represent operator reactions, which matters for reasoning about RBAC.
+ */
+public class ClusterUser {
+
+    private final KubernetesClient client;
+    private final String namespace;
+
+    ClusterUser(@NonNull KubernetesClient client, @NonNull String namespace) {
+        this.client = client;
+        this.namespace = namespace;
+    }
+
+    @NonNull
+    public <T extends HasMetadata> T create(@NonNull T resource) {
+        return client.resource(resource).inNamespace(namespace).create();
+    }
+
+    @Nullable
+    public <T extends HasMetadata> T get(@NonNull Class<T> type, @NonNull String name) {
+        return client.resources(type).inNamespace(namespace).withName(name).get();
+    }
+
+    @NonNull
+    public <T extends HasMetadata> T replace(@NonNull T resource) {
+        return client.resource(resource).inNamespace(namespace).update();
+    }
+
+    public <T extends HasMetadata> boolean delete(@NonNull T resource) {
+        var result = client.resource(resource).inNamespace(namespace).delete();
+        return result.size() == 1 && result.get(0).getCauses().isEmpty();
+    }
+
+    @NonNull
+    public <T extends HasMetadata> NonNamespaceOperation<T, KubernetesResourceList<T>, Resource<T>> resources(@NonNull Class<T> type) {
+        return client.resources(type).inNamespace(namespace);
+    }
+}

--- a/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/kubernetes/operator/LocalKroxyliciousOperatorExtension.java
+++ b/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/kubernetes/operator/LocalKroxyliciousOperatorExtension.java
@@ -264,6 +264,19 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         return localOperatorExtension.getNamespace();
     }
 
+    /**
+     * Returns a {@link ClusterUser} backed by the admin Kubernetes client, scoped to the test namespace.
+     * <p>
+     * Use this to represent user-side interactions (creating CRs, reading state) as opposed to
+     * operator reactions. The operator is the system-under-test; the {@code ClusterUser} is the actor.
+     * <p>
+     * Must be called after {@code beforeAll}.
+     */
+    @NonNull
+    public ClusterUser clusterUser() {
+        return new ClusterUser(rbacHandler.userClient(), localOperatorExtension.getNamespace());
+    }
+
     // ---- resource operations ----
 
     @NonNull

--- a/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/kubernetes/operator/LocalKroxyliciousOperatorExtension.java
+++ b/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/kubernetes/operator/LocalKroxyliciousOperatorExtension.java
@@ -29,10 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.readiness.Readiness;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
@@ -45,7 +42,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A JUnit 5 extension that runs a Kroxylicious operator locally for integration testing.
@@ -277,23 +273,6 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         return new ClusterUser(rbacHandler.userClient(), localOperatorExtension.getNamespace());
     }
 
-    // ---- resource operations ----
-
-    @NonNull
-    public <T extends HasMetadata> T create(@NonNull T resource) {
-        return testActor.create(resource);
-    }
-
-    @Nullable
-    public <T extends HasMetadata> T get(@NonNull Class<T> type, @NonNull String name) {
-        return testActor.get(type, name);
-    }
-
-    @NonNull
-    public <T extends HasMetadata> T replace(@NonNull T resource) {
-        return testActor.replace(resource);
-    }
-
     @NonNull
     public <T extends HasMetadata> T patchStatus(@NonNull T resource) {
         return testActor.patchStatus(resource);
@@ -318,14 +297,6 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         return testActor.patchStatus(mutated);
     }
 
-    public <T extends HasMetadata> boolean delete(@NonNull T resource) {
-        return testActor.delete(resource);
-    }
-
-    @NonNull
-    public <T extends HasMetadata> NonNamespaceOperation<T, KubernetesResourceList<T>, Resource<T>> resources(@NonNull Class<T> type) {
-        return testActor.resources(type);
-    }
 
     public static Builder builder() {
         return new Builder();

--- a/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/kubernetes/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/kubernetes/operator/LocallyRunningOperatorRbacHandler.java
@@ -204,10 +204,23 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
         return new KubernetesClientBuilder().editOrNewConfig().withImpersonateUsername(impersonatedUser).endConfig().build();
     }
 
+    /**
+     * Returns the Kubernetes client used for user-level interactions.
+     * <p>
+     * This client has the RBAC rights of a cluster user (via the admin client), not the operator.
+     * The client is created lazily on first call and closed in {@link #afterAll}.
+     */
+    @NonNull
+    public KubernetesClient userClient() {
+        if (testActorClient == null) {
+            testActorClient = adminClientFactory.get();
+        }
+        return testActorClient;
+    }
+
     @NonNull
     public TestActor testActor(@NonNull AbstractOperatorExtension operatorExtension) {
-        testActorClient = adminClientFactory.get();
-        var client = testActorClient;
+        var client = userClient();
         return new TestActor() {
 
             @NonNull

--- a/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/kubernetes/operator/ClusterUserTest.java
+++ b/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/kubernetes/operator/ClusterUserTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableKubernetesMockClient(crud = true)
+class ClusterUserTest {
+
+    private static final String NAMESPACE = "test-ns";
+
+    KubernetesClient client;
+
+    @BeforeEach
+    void createNamespace() {
+        client.namespaces().resource(new io.fabric8.kubernetes.api.model.NamespaceBuilder()
+                .withNewMetadata().withName(NAMESPACE).endMetadata().build()).create();
+    }
+
+    @Test
+    void createPersistsResourceInNamespace() {
+        var user = new ClusterUser(client, NAMESPACE);
+        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("my-proxy").endMetadata().build();
+
+        user.create(proxy);
+
+        assertThat(client.resources(KafkaProxy.class).inNamespace(NAMESPACE).withName("my-proxy").get())
+                .isNotNull();
+    }
+
+    @Test
+    void getReturnsResourceByName() {
+        var user = new ClusterUser(client, NAMESPACE);
+        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("my-proxy").endMetadata().build();
+        client.resource(proxy).inNamespace(NAMESPACE).create();
+
+        KafkaProxy result = user.get(KafkaProxy.class, "my-proxy");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getMetadata().getName()).isEqualTo("my-proxy");
+    }
+
+    @Test
+    void getMissingResourceReturnsNull() {
+        var user = new ClusterUser(client, NAMESPACE);
+
+        assertThat(user.get(KafkaProxy.class, "does-not-exist")).isNull();
+    }
+
+    @Test
+    void replaceUpdatesExistingResource() {
+        var user = new ClusterUser(client, NAMESPACE);
+        Secret secret = new SecretBuilder().withNewMetadata().withName("my-secret").endMetadata()
+                .addToStringData("key", "original").build();
+        client.resource(secret).inNamespace(NAMESPACE).create();
+
+        Secret updated = new SecretBuilder(secret).addToStringData("key", "updated").build();
+        user.replace(updated);
+
+        Secret fetched = client.resources(Secret.class).inNamespace(NAMESPACE).withName("my-secret").get();
+        assertThat(fetched.getStringData()).containsEntry("key", "updated");
+    }
+
+    @Test
+    void deleteRemovesResourceFromNamespace() {
+        var user = new ClusterUser(client, NAMESPACE);
+        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("my-proxy").endMetadata().build();
+        client.resource(proxy).inNamespace(NAMESPACE).create();
+
+        user.delete(proxy);
+
+        assertThat(client.resources(KafkaProxy.class).inNamespace(NAMESPACE).withName("my-proxy").get())
+                .isNull();
+    }
+
+    @Test
+    void resourcesReturnsNamespaceScopedOperation() {
+        var user = new ClusterUser(client, NAMESPACE);
+        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("my-proxy").endMetadata().build();
+        client.resource(proxy).inNamespace(NAMESPACE).create();
+
+        var items = user.resources(KafkaProxy.class).list().getItems();
+
+        assertThat(items).hasSize(1);
+        assertThat(items.get(0).getMetadata().getName()).isEqualTo("my-proxy");
+    }
+}

--- a/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/kubernetes/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
+++ b/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/kubernetes/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
@@ -234,6 +235,16 @@ class LocalKroxyliciousOperatorExtensionLifecycleTest {
         verify(mutator).apply(fresh);
         verify(actor).patchStatus(fresh);
         assertThat(result).isSameAs(patched);
+    }
+
+    @Test
+    void clusterUserIsNonNullAfterBeforeAll() throws Exception {
+        when(locallyRunOperatorExtension.getNamespace()).thenReturn("test-ns");
+        when(rbacHandler.userClient()).thenReturn(mock(KubernetesClient.class));
+
+        extension.beforeAll(context);
+
+        assertThat(extension.clusterUser()).isNotNull();
     }
 
     // ---- helpers ----

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -106,6 +107,13 @@ class AllReconcilersIT {
             })
             .build();
 
+    private ClusterUser clusterUser;
+
+    @BeforeEach
+    void setUp() {
+        clusterUser = operator.clusterUser();
+    }
+
     @Test
     void emptyProxyIsAllowed() {
         // Given
@@ -121,13 +129,13 @@ class AllReconcilersIT {
 
     static Stream<Arguments> filterScenarios() {
         return Stream.of(
-                argumentSet("no filters", (Function<LocalKroxyliciousOperatorExtension, KafkaProtocolFilter>) (builder -> null)),
-                argumentSet("filter with simple config", (Function<LocalKroxyliciousOperatorExtension, KafkaProtocolFilter>) (actor -> {
+                argumentSet("no filters", (Function<ClusterUser, KafkaProtocolFilter>) (builder -> null)),
+                argumentSet("filter with simple config", (Function<ClusterUser, KafkaProtocolFilter>) (actor -> {
                     var filter = editableFilter(CLUSTER_FOO_FILTER).build();
                     actor.create(filter);
                     return filter;
                 })),
-                argumentSet("filter with config that refs a configmap", (Function<LocalKroxyliciousOperatorExtension, KafkaProtocolFilter>) (actor -> {
+                argumentSet("filter with config that refs a configmap", (Function<ClusterUser, KafkaProtocolFilter>) (actor -> {
                 // @formatter:off
                     var filterConfigMap = new ConfigMapBuilder()
                             .withNewMetadata()
@@ -149,7 +157,7 @@ class AllReconcilersIT {
 
     @ParameterizedTest
     @MethodSource("filterScenarios")
-    void singleVirtualCluster(Function<LocalKroxyliciousOperatorExtension, KafkaProtocolFilter> filterFunc) {
+    void singleVirtualCluster(Function<ClusterUser, KafkaProtocolFilter> filterFunc) {
         // Given
         var myProxy = editableProxy(PROXY_A).build();
         // @formatter:off
@@ -163,7 +171,7 @@ class AllReconcilersIT {
         // @formatter:on
         var myService = editableService(CLUSTER_FOO_SERVICE).build();
 
-        var myFilter = filterFunc.apply(operator);
+        var myFilter = filterFunc.apply(clusterUser);
 
         var myCluster = editableVirtualCluster(CLUSTER_FOO, myProxy, myService, List.of(myIngress), Optional.ofNullable(myFilter).stream().toList()).build();
 
@@ -181,7 +189,7 @@ class AllReconcilersIT {
         // so we wait explicitly for the ingresses to be populated rather than checking the
         // snapshot returned when the accepted condition first became true.
         AWAIT.alias("cluster %s has ingresses with bootstrap servers".formatted(CLUSTER_FOO))
-                .untilAsserted(() -> assertThat(operator.get(VirtualKafkaCluster.class, CLUSTER_FOO))
+                .untilAsserted(() -> assertThat(clusterUser.get(VirtualKafkaCluster.class, CLUSTER_FOO))
                         .isNotNull()
                         .extracting(VirtualKafkaCluster::getStatus)
                         .satisfies(vcs -> assertThat(vcs)
@@ -194,8 +202,8 @@ class AllReconcilersIT {
 
     static Stream<Arguments> upstreamTlsScenarios() {
         return Stream.of(
-                argumentSet("tls", (Function<LocalKroxyliciousOperatorExtension, Tls>) (builder -> new Tls())),
-                argumentSet("tls with trust from secret", (Function<LocalKroxyliciousOperatorExtension, Tls>) (actor -> {
+                argumentSet("tls", (Function<ClusterUser, Tls>) (builder -> new Tls())),
+                argumentSet("tls with trust from secret", (Function<ClusterUser, Tls>) (actor -> {
                 // @formatter:off
                     var trust = new SecretBuilder()
                             .withNewMetadata()
@@ -216,7 +224,7 @@ class AllReconcilersIT {
                     actor.create(trust);
                     return ref;
                 })),
-                argumentSet("tls with trust from secret with store type", (Function<LocalKroxyliciousOperatorExtension, Tls>) (actor -> {
+                argumentSet("tls with trust from secret with store type", (Function<ClusterUser, Tls>) (actor -> {
                 // @formatter:off
                     var trust = new SecretBuilder()
                             .withNewMetadata()
@@ -242,9 +250,9 @@ class AllReconcilersIT {
 
     @ParameterizedTest
     @MethodSource("upstreamTlsScenarios")
-    void upstreamTls(Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.Tls> tlsFunc) {
+    void upstreamTls(Function<ClusterUser, io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.Tls> tlsFunc) {
         // Given
-        var tlsScenario = tlsFunc.apply(operator);
+        var tlsScenario = tlsFunc.apply(clusterUser);
 
         var myProxy = editableProxy(PROXY_A).build();
         // @formatter:off
@@ -292,12 +300,12 @@ class AllReconcilersIT {
 
         return Stream.of(
                 argumentSet("tls with platform trust",
-                        (Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
+                        (Function<ClusterUser, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
                             actor.create(downstreamCert);
                             return new io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.TlsBuilder(downstreamTls).build();
                         })),
                 argumentSet("tls with trust from configmap",
-                        (Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
+                        (Function<ClusterUser, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
 
                         // @formatter:off
                     var downstreamTrust = new ConfigMapBuilder()
@@ -320,7 +328,7 @@ class AllReconcilersIT {
                             return tls;
                         })),
                 argumentSet("tls with trust from secret",
-                        (Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
+                        (Function<ClusterUser, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
 
                         // @formatter:off
                     var downstreamTrust = new SecretBuilder()
@@ -344,7 +352,7 @@ class AllReconcilersIT {
                             return tls;
                         })),
                 argumentSet("tls with trust from configmap with new key of supported store type",
-                        (Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
+                        (Function<ClusterUser, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
 
                         // @formatter:off
                     var downstreamTrust = new ConfigMapBuilder()
@@ -371,9 +379,9 @@ class AllReconcilersIT {
 
     @ParameterizedTest
     @MethodSource("downstreamTlsScenarios")
-    void downstreamTls(Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls> tlsFunc) {
+    void downstreamTls(Function<ClusterUser, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls> tlsFunc) {
         // Given
-        var tlsScenario = tlsFunc.apply(operator);
+        var tlsScenario = tlsFunc.apply(clusterUser);
 
         var myProxy = editableProxy(PROXY_A).build();
         // @formatter:off
@@ -405,7 +413,7 @@ class AllReconcilersIT {
     }
 
     private void createAll(HasMetadata... resources) {
-        Arrays.stream(resources).sequential().forEach(operator::create);
+        Arrays.stream(resources).sequential().forEach(clusterUser::create);
     }
 
     private static KafkaProxyBuilder editableProxy(String name) {
@@ -428,7 +436,7 @@ class AllReconcilersIT {
         var name = name(resource);
         var clazz = resource.getClass();
         AWAIT.alias("resource %s (%s) meets predicate".formatted(name, clazz.getSimpleName()))
-                .untilAsserted(() -> operator.get(clazz, name),
+                .untilAsserted(() -> clusterUser.get(clazz, name),
                         actual -> {
                             assertThat(actual)
                                     .isNotNull()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
@@ -189,7 +189,7 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateStatusOnSecretDelete() {
         var filterOne = createFilterFirst();
 
-        operator.delete(secret(A));
+        clusterUser.delete(secret(A));
         assertResolvedRefsFalse(filterOne, "Referenced Secrets [a] not found");
     }
 
@@ -197,7 +197,7 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateStatusOnConfigMapDelete() {
         var filterOne = createFilterFirst();
 
-        operator.delete(cm(B));
+        clusterUser.delete(cm(B));
         assertResolvedRefsFalse(filterOne, "Referenced ConfigMaps [b] not found");
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
@@ -13,6 +13,7 @@ import java.util.Base64;
 import java.util.Map;
 
 import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -26,6 +27,7 @@ import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilter;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilterBuilder;
 import io.kroxylicious.kubernetes.operator.Annotations;
+import io.kroxylicious.kubernetes.operator.ClusterUser;
 import io.kroxylicious.kubernetes.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
@@ -51,38 +53,45 @@ class KafkaProtocolFilterReconcilerIT {
             .replaceClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
             .build();
 
+    private ClusterUser clusterUser;
+
+    @BeforeEach
+    void setUp() {
+        clusterUser = operator.clusterUser();
+    }
+
     @Test
     void shouldEventuallyResolveWhenFilterCreatedFirst() {
         createFilterFirst();
     }
 
     private KafkaProtocolFilter createFilterFirst() {
-        KafkaProtocolFilter filterOne = operator.create(filter(FILTER_ONE,
+        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE,
                 "${secret:" + A + ":foo}", "${configmap:" + B + ":foo}"));
         assertResolvedRefsFalse(filterOne, "Referenced Secrets [a] ConfigMaps [b] not found");
-        operator.create(secret(A));
+        clusterUser.create(secret(A));
         assertResolvedRefsFalse(filterOne, "Referenced ConfigMaps [b] not found");
-        operator.create(cm(B));
+        clusterUser.create(cm(B));
         assertAllConditionsTrue(filterOne);
         return filterOne;
     }
 
     @Test
     void shouldEventuallyResolveWhenASecretCreatedFirst() {
-        operator.create(secret(A));
-        KafkaProtocolFilter filterOne = operator.create(filter(FILTER_ONE,
+        clusterUser.create(secret(A));
+        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE,
                 "${secret:" + A + ":foo}", "${secret:" + B + ":foo}"));
         assertResolvedRefsFalse(filterOne, "Referenced Secrets [b] not found");
-        operator.create(secret(B));
+        clusterUser.create(secret(B));
         assertAllConditionsTrue(filterOne);
     }
 
     @Test
     void shouldEventuallyResolveWhenAllSecretsCreatedFirst() {
-        operator.create(secret(A));
-        operator.create(secret(B));
-        operator.create(secret(C));
-        KafkaProtocolFilter filterOne = operator.create(filter(FILTER_ONE,
+        clusterUser.create(secret(A));
+        clusterUser.create(secret(B));
+        clusterUser.create(secret(C));
+        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE,
                 "${secret:" + A + ":foo}",
                 "${secret:" + B + ":foo}"));
         assertAllConditionsTrue(filterOne);
@@ -90,7 +99,7 @@ class KafkaProtocolFilterReconcilerIT {
 
     private void assertAllConditionsTrue(KafkaProtocolFilter filterOne) {
         AWAIT.alias("FilterStatusResolvedRefs").untilAsserted(() -> {
-            var kpf = operator.resources(KafkaProtocolFilter.class)
+            var kpf = clusterUser.resources(KafkaProtocolFilter.class)
                     .withName(ResourcesUtil.name(filterOne)).get();
             assertThat(kpf.getStatus()).isNotNull();
             KafkaProtocolFilterStatusAssert
@@ -107,10 +116,10 @@ class KafkaProtocolFilterReconcilerIT {
 
     @Test
     void shouldEventuallyResolveWhenSecretsAndConfigMapsFirst() {
-        operator.create(secret(A));
-        operator.create(cm(B));
-        operator.create(secret(C));
-        KafkaProtocolFilter filterOne = operator.create(filter(FILTER_ONE,
+        clusterUser.create(secret(A));
+        clusterUser.create(cm(B));
+        clusterUser.create(secret(C));
+        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE,
                 "${secret:" + A + ":foo}",
                 "${configmap:" + B + ":foo}"));
         assertAllConditionsTrue(filterOne);
@@ -120,11 +129,11 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateStatusOnFilterModify() {
         shouldEventuallyResolveWhenFilterCreatedFirst();
 
-        KafkaProtocolFilter filterOne = operator.replace(filter(FILTER_ONE,
+        KafkaProtocolFilter filterOne = clusterUser.replace(filter(FILTER_ONE,
                 "${secret:" + C + ":foo}", "${configmap:" + B + ":foo}"));
         assertResolvedRefsFalse(filterOne, "Referenced Secrets [c] not found");
 
-        operator.create(secret(C));
+        clusterUser.create(secret(C));
         assertAllConditionsTrue(filterOne);
     }
 
@@ -132,7 +141,7 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateStatusOnSecretModify() {
         var filterOne = createFilterFirst();
 
-        operator.resources(Secret.class).withName(A).edit(secret -> secret.edit()
+        clusterUser.resources(Secret.class).withName(A).edit(secret -> secret.edit()
                 .addToData("baz", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
                 .build());
         assertAllConditionsTrue(filterOne);
@@ -142,17 +151,17 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateReferentAnnotationOnSecretModify() {
         // given
         var filterOne = createFilterFirst();
-        String checksum = operator.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+        String checksum = clusterUser.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
                 .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
 
         // when
-        operator.resources(Secret.class).withName(A).edit(secret -> secret.edit()
+        clusterUser.resources(Secret.class).withName(A).edit(secret -> secret.edit()
                 .addToData("baz", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
                 .build());
 
         // then
         assertAllConditionsTrue(filterOne);
-        String newChecksum = operator.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+        String newChecksum = clusterUser.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
                 .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
         assertThat(newChecksum).isNotEqualTo(checksum);
     }
@@ -161,17 +170,17 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateReferentAnnotationOnConfigMapModify() {
         // given
         var filterOne = createFilterFirst();
-        String checksum = operator.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+        String checksum = clusterUser.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
                 .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
 
         // when
-        operator.resources(ConfigMap.class).withName(B).edit(configMap -> configMap.edit()
+        clusterUser.resources(ConfigMap.class).withName(B).edit(configMap -> configMap.edit()
                 .addToData("baz", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
                 .build());
 
         // then
         assertAllConditionsTrue(filterOne);
-        String newChecksum = operator.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+        String newChecksum = clusterUser.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
                 .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
         assertThat(newChecksum).isNotEqualTo(checksum);
     }
@@ -212,7 +221,7 @@ class KafkaProtocolFilterReconcilerIT {
     private void assertResolvedRefsFalse(KafkaProtocolFilter cr,
                                          String message) {
         AWAIT.alias("FilterStatusResolvedRefs").untilAsserted(() -> {
-            var kpf = operator.resources(KafkaProtocolFilter.class)
+            var kpf = clusterUser.resources(KafkaProtocolFilter.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(kpf.getStatus()).isNotNull();
             KafkaProtocolFilterStatusAssert

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -88,6 +89,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRangesBuil
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.Ingresses;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressesBuilder;
 import io.kroxylicious.kubernetes.operator.Annotations;
+import io.kroxylicious.kubernetes.operator.ClusterUser;
 import io.kroxylicious.kubernetes.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
@@ -154,6 +156,13 @@ public class KafkaProxyReconcilerIT {
     static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
             .withReconciler(new KafkaProxyReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR))
             .build();
+
+    private ClusterUser clusterUser;
+
+    @BeforeEach
+    void setUp() {
+        clusterUser = operator.clusterUser();
+    }
 
     @Test
     void testCreate() {
@@ -338,7 +347,7 @@ public class KafkaProxyReconcilerIT {
         String namespace = operator.getNamespace();
         String resourceName = resourceNameFn.apply(proxy);
 
-        AWAIT.alias(resourceName + " to exist").untilAsserted(() -> assertThat(operator.get(resourceClass, resourceName)).isNotNull());
+        AWAIT.alias(resourceName + " to exist").untilAsserted(() -> assertThat(clusterUser.get(resourceClass, resourceName)).isNotNull());
 
         // when — an external tool applies an SSA patch with its own field manager
         try (var client = new KubernetesClientBuilder().build()) {
@@ -348,15 +357,15 @@ public class KafkaProxyReconcilerIT {
         }
 
         // when — trigger a reconcile by changing the replica count
-        KafkaProxy updatedProxy = Objects.requireNonNull(operator.get(KafkaProxy.class, name(proxy)))
+        KafkaProxy updatedProxy = Objects.requireNonNull(clusterUser.get(KafkaProxy.class, name(proxy)))
                 .edit().editSpec().withReplicas(2).endSpec().build();
-        operator.replace(updatedProxy);
+        clusterUser.replace(updatedProxy);
 
         // then — wait for reconcile to complete (observable via Deployment replica change)
         assertDeploymentReplicaCount(proxy, 2);
 
         // then — external annotation must still be present after the operator reconciled
-        assertThat(operator.get(resourceClass, resourceName))
+        assertThat(clusterUser.get(resourceClass, resourceName))
                 .isNotNull()
                 .extracting(r -> r.getMetadata().getAnnotations(),
                         InstanceOfAssertFactories.map(String.class, String.class))
@@ -413,8 +422,8 @@ public class KafkaProxyReconcilerIT {
     @Test
     void testCreateWithKafkaServiceTls() {
         // given
-        operator.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME));
-        operator.create(trustAnchorConfigMap(CA_BUNDLE_CONFIG_MAP_NAME));
+        clusterUser.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME));
+        clusterUser.create(trustAnchorConfigMap(CA_BUNDLE_CONFIG_MAP_NAME));
         KafkaService kafkaService = kafkaServiceWithTls();
 
         // when
@@ -435,8 +444,8 @@ public class KafkaProxyReconcilerIT {
     @Test
     void testCreateWithKafkaServiceTlsUsingTrustAnchorFromSecret() {
         // given
-        operator.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME));
-        operator.create(trustAnchorSecret(CA_CERT_SECRET_NAME));
+        clusterUser.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME));
+        clusterUser.create(trustAnchorSecret(CA_CERT_SECRET_NAME));
         KafkaService kafkaService = kafkaServiceWithTlsWithTrustAnchorRefAsSecret();
 
         // when
@@ -455,20 +464,20 @@ public class KafkaProxyReconcilerIT {
     @Test
     void virtualClusterWithClusterIpIngress() {
         // Given
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
 
-        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress ingress = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
+        KafkaProxyIngress ingress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
 
         String downstreamCertSecretName = "downstream-tls-certificate";
-        Secret tlsCert = operator.create(tlsKeyAndCertSecret(downstreamCertSecretName));
+        Secret tlsCert = clusterUser.create(tlsKeyAndCertSecret(downstreamCertSecretName));
 
         Ingresses build = createIngressForCluster(ingress, tlsCert);
         VirtualKafkaCluster resource = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(build), Optional.empty());
 
         // When
-        updateStatusObservedGeneration(operator.create(resource));
+        updateStatusObservedGeneration(clusterUser.create(resource));
 
         // Then
         assertProxyConfigContents(proxy, Set.of(downstreamCertSecretName), Set.of());
@@ -478,15 +487,15 @@ public class KafkaProxyReconcilerIT {
     @Test
     void virtualClusterWithClusterIpIngressWithTrustAnchor() {
         // Given
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
 
-        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress ingress = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
+        KafkaProxyIngress ingress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
 
-        Secret tlsServerCert = operator.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
+        Secret tlsServerCert = clusterUser.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
         String downstreamTrustAnchorName = "downstream-tls-trust-anchor";
-        ConfigMap trustAnchor = operator.create(trustAnchorConfigMap(downstreamTrustAnchorName));
+        ConfigMap trustAnchor = clusterUser.create(trustAnchorConfigMap(downstreamTrustAnchorName));
 
         Ingresses clusterIngress = new IngressesBuilder()
                 .withIngressRef(toIngressRef(ingress))
@@ -499,7 +508,7 @@ public class KafkaProxyReconcilerIT {
         VirtualKafkaCluster resource = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress), Optional.empty());
 
         // When
-        updateStatusObservedGeneration(operator.create(resource));
+        updateStatusObservedGeneration(clusterUser.create(resource));
 
         // Then
         int clientFacingPort = TlsClusterIPClusterIngressNetworkingModel.CLIENT_FACING_PORT;
@@ -529,16 +538,16 @@ public class KafkaProxyReconcilerIT {
     @Test
     void virtualClusterWithMultipleClusterIpIngressWithTrustAnchor() {
         // Given
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
 
-        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress ingress = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
-        KafkaProxyIngress ingress2 = updateStatusObservedGeneration(operator.create(clusterIpIngress("another-cluster-ip", proxy, TLS)));
+        KafkaProxyIngress ingress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
+        KafkaProxyIngress ingress2 = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress("another-cluster-ip", proxy, TLS)));
 
-        Secret tlsServerCert = operator.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
+        Secret tlsServerCert = clusterUser.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
         String downstreamTrustAnchorName = "downstream-tls-trust-anchor";
-        ConfigMap trustAnchor = operator.create(trustAnchorConfigMap(downstreamTrustAnchorName));
+        ConfigMap trustAnchor = clusterUser.create(trustAnchorConfigMap(downstreamTrustAnchorName));
 
         Ingresses clusterIngress = new IngressesBuilder()
                 .withIngressRef(toIngressRef(ingress))
@@ -559,7 +568,7 @@ public class KafkaProxyReconcilerIT {
         VirtualKafkaCluster resource = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress, clusterIngress2), Optional.empty());
 
         // When
-        updateStatusObservedGeneration(operator.create(resource));
+        updateStatusObservedGeneration(clusterUser.create(resource));
 
         // Then
         int clientFacingPort = TlsClusterIPClusterIngressNetworkingModel.CLIENT_FACING_PORT;
@@ -598,7 +607,7 @@ public class KafkaProxyReconcilerIT {
     }
 
     private void assertTlsClusterIpServiceManifested(String serviceName, KafkaProxy proxy, int clientFacingPort, int proxyListenPort) {
-        var service = operator.get(Service.class, serviceName);
+        var service = clusterUser.get(Service.class, serviceName);
         assertThat(service).isNotNull()
                 .describedAs(
                         "Expect Service '" + serviceName + " to exist")
@@ -615,18 +624,18 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void virtualClusterWithLoadBalancerIngressWithTrustAnchor() {
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
         String loadbalancerBootstrap = "bootstrap.kafka";
         String loadbalancerBrokerAddressPattern = "broker-$(nodeId).kafka";
         KafkaProxyIngress loadBalancerIngress = updateStatusObservedGeneration(
-                operator.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy, loadbalancerBootstrap,
+                clusterUser.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy, loadbalancerBootstrap,
                         loadbalancerBrokerAddressPattern)));
 
-        Secret tlsServerCert = operator.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
+        Secret tlsServerCert = clusterUser.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
         String downstreamTrustAnchorName = "downstream-tls-trust-anchor";
-        ConfigMap trustAnchor = operator.create(trustAnchorConfigMap(downstreamTrustAnchorName));
+        ConfigMap trustAnchor = clusterUser.create(trustAnchorConfigMap(downstreamTrustAnchorName));
 
         Ingresses clusterIngress = new IngressesBuilder()
                 .withIngressRef(toIngressRef(loadBalancerIngress))
@@ -638,14 +647,14 @@ public class KafkaProxyReconcilerIT {
         VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress), Optional.empty());
 
         // when
-        updateStatusObservedGeneration(operator.create(cluster));
+        updateStatusObservedGeneration(clusterUser.create(cluster));
 
         int clientFacingPort = LoadBalancerClusterIngressNetworkingModel.DEFAULT_CLIENT_FACING_LOADBALANCER_PORT;
         int proxyListenPort = ProxyDeploymentDependentResource.SHARED_SNI_PORT;
 
         AWAIT.alias("shared sni service manifested").untilAsserted(() -> {
             String serviceName = name(proxy) + "-sni";
-            var service = operator.get(Service.class, serviceName);
+            var service = clusterUser.get(Service.class, serviceName);
             assertThat(service).isNotNull()
                     .describedAs(
                             "Expect shared SNI Service for proxy '" + name(proxy) + " to exist")
@@ -675,7 +684,7 @@ public class KafkaProxyReconcilerIT {
 
     private void assertSharedSniPortExposedOnProxyDeployment(KafkaProxy proxy, int proxyListenPort) {
         AWAIT.alias("proxy deployment exposes shared sni port").untilAsserted(() -> {
-            var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+            var deployment = clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
             assertThat(deployment).isNotNull();
             List<Container> containers = deployment.getSpec().getTemplate().getSpec().getContainers();
             assertThat(containers).hasSize(1).singleElement().satisfies(container -> {
@@ -692,33 +701,33 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void virtualClusterWithLoadBalancerAndClusterIpIngress() {
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress loadBalancerIngress = updateStatusObservedGeneration(operator.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy,
+        KafkaProxyIngress loadBalancerIngress = updateStatusObservedGeneration(clusterUser.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy,
                 "bootstrap.kafka",
                 "broker-$(nodeId).kafka")));
 
-        Secret loadBalancerTlsServerCert = operator.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate"));
+        Secret loadBalancerTlsServerCert = clusterUser.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate"));
 
         Ingresses lbIngress = createIngressForCluster(loadBalancerIngress, loadBalancerTlsServerCert);
 
-        Secret clusterIpTlsServerCert = operator.create(tlsKeyAndCertSecret("clusterip-tls-certificate"));
+        Secret clusterIpTlsServerCert = clusterUser.create(tlsKeyAndCertSecret("clusterip-tls-certificate"));
 
-        KafkaProxyIngress clusterIpIngress = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
+        KafkaProxyIngress clusterIpIngress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
 
         Ingresses cipIngress = createIngressForCluster(clusterIpIngress, clusterIpTlsServerCert);
 
         VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(lbIngress, cipIngress), Optional.empty());
 
         // when
-        updateStatusObservedGeneration(operator.create(cluster));
+        updateStatusObservedGeneration(clusterUser.create(cluster));
 
         // then
         AWAIT.alias("services manifested").untilAsserted(() -> {
             String sharedSniServiceName = name(proxy) + "-sni";
             String clusterIpServiceName = CLUSTER_BAR + "-" + clusterIpIngress.getMetadata().getName() + "-bootstrap";
-            var services = operator.resources(Service.class).list().getItems();
+            var services = clusterUser.resources(Service.class).list().getItems();
             assertThat(services)
                     .extracting(service -> service.getMetadata().getName())
                     .contains(sharedSniServiceName, clusterIpServiceName);
@@ -733,26 +742,26 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void twoVirtualClusterUsingLoadBalancer() {
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress loadBalancerIngressFoo = updateStatusObservedGeneration(operator.create(loadBalancerIngress(CLUSTER_FOO_LOADBALANCER_INGRESS, proxy,
+        KafkaProxyIngress loadBalancerIngressFoo = updateStatusObservedGeneration(clusterUser.create(loadBalancerIngress(CLUSTER_FOO_LOADBALANCER_INGRESS, proxy,
                 "bootstrap.foo.kafka",
                 "broker-$(nodeId).foo.kafka")));
 
-        KafkaProxyIngress loadBalancerIngressBar = updateStatusObservedGeneration(operator.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy,
+        KafkaProxyIngress loadBalancerIngressBar = updateStatusObservedGeneration(clusterUser.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy,
                 "bootstrap.bar.kafka",
                 "broker-$(nodeId).bar.kafka")));
 
-        Secret loadBalancerTlsServerCertFoo = operator.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-foo"));
-        Secret loadBalancerTlsServerCertBar = operator.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-bar"));
+        Secret loadBalancerTlsServerCertFoo = clusterUser.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-foo"));
+        Secret loadBalancerTlsServerCertBar = clusterUser.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-bar"));
 
         Ingresses lbIngressFoo = createIngressForCluster(loadBalancerIngressFoo, loadBalancerTlsServerCertFoo);
 
         Ingresses lbIngressBar = createIngressForCluster(loadBalancerIngressBar, loadBalancerTlsServerCertBar);
 
-        VirtualKafkaCluster fooCluster = operator.create(virtualKafkaCluster(CLUSTER_FOO, proxy, kafkaService, List.of(lbIngressFoo), Optional.empty()));
-        VirtualKafkaCluster barCluster = operator.create(virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(lbIngressBar), Optional.empty()));
+        VirtualKafkaCluster fooCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_FOO, proxy, kafkaService, List.of(lbIngressFoo), Optional.empty()));
+        VirtualKafkaCluster barCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(lbIngressBar), Optional.empty()));
 
         // when
         List.of(fooCluster, barCluster).forEach(this::updateStatusObservedGeneration);
@@ -760,7 +769,7 @@ public class KafkaProxyReconcilerIT {
         // then
         AWAIT.alias("shared sni service manifested").untilAsserted(() -> {
             String sharedSniServiceName = name(proxy) + "-sni";
-            var services = operator.resources(Service.class).list().getItems();
+            var services = clusterUser.resources(Service.class).list().getItems();
             assertThat(services)
                     .extracting(service -> service.getMetadata().getName())
                     .containsExactly(sharedSniServiceName);
@@ -783,17 +792,17 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void clusterIpIngressUsesDeclaredNodeIdsOfService() {
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
-        KafkaProtocolFilter filter = operator.create(filter(FILTER_NAME));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaProtocolFilter filter = clusterUser.create(filter(FILTER_NAME));
         filter = updateStatusObservedGeneration(filter);
-        KafkaService barService = operator.create(new KafkaServiceBuilder().withNewMetadata().withName(CLUSTER_BAR_REF).endMetadata()
+        KafkaService barService = clusterUser.create(new KafkaServiceBuilder().withNewMetadata().withName(CLUSTER_BAR_REF).endMetadata()
                 .withNewSpec()
                 .withBootstrapServers(CLUSTER_BAR_BOOTSTRAP)
                 .withNodeIdRanges(createNodeIdRanges("brokers", 3L, 4L), createNodeIdRanges("more-brokers", 10L, 10L))
                 .endSpec().build());
         barService = updateStatusObservedGeneration(barService, CLUSTER_BAR_BOOTSTRAP);
-        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TCP)));
-        VirtualKafkaCluster clusterBar = operator.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barService,
+        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TCP)));
+        VirtualKafkaCluster clusterBar = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressBar)).build()), Optional.of(filter)));
         updateStatusObservedGeneration(clusterBar);
         clusterBar.setStatus(new VirtualKafkaClusterStatusBuilder().withObservedGeneration(generation(clusterBar)).build());
@@ -803,7 +812,7 @@ public class KafkaProxyReconcilerIT {
             String clusterName = name(clusterBar);
             String ingressName = name(ingressBar);
             String serviceName = clusterName + "-" + ingressName + "-bootstrap";
-            var service = operator.get(Service.class, serviceName);
+            var service = clusterUser.get(Service.class, serviceName);
             assertThat(service).isNotNull()
                     .describedAs(
                             "Expect Service for cluster '" + clusterName + "' and ingress '" + ingressName + "' to still exist")
@@ -818,7 +827,7 @@ public class KafkaProxyReconcilerIT {
         });
 
         AWAIT.alias("deployment pod template configured to expose ports").untilAsserted(() -> {
-            var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+            var deployment = clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
             assertThat(deployment).isNotNull();
             List<Container> containers = deployment.getSpec().getTemplate().getSpec().getContainers();
             assertThat(containers).hasSize(1).singleElement().satisfies(container -> {
@@ -862,8 +871,8 @@ public class KafkaProxyReconcilerIT {
 
         // Given
         var domain = getDefaultOpenShiftIngressControllerDomain();
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
         int proxyListenPort = ProxyDeploymentDependentResource.SHARED_SNI_PORT;
 
@@ -871,21 +880,21 @@ public class KafkaProxyReconcilerIT {
         String routeBootstrap = "$(virtualClusterName)-bootstrap." + domain;
         String routeBrokerAddressPattern = "$(virtualClusterName)-$(nodeId)." + domain;
         KafkaProxyIngress openshiftRouteIngress = updateStatusObservedGeneration(
-                operator.create(openshiftRouteIngress(ingressName, proxy)));
+                clusterUser.create(openshiftRouteIngress(ingressName, proxy)));
 
         String downstreamCertSecretName = "downstream-tls-certificate";
-        Secret tlsCert = operator.create(tlsKeyAndCertSecret(downstreamCertSecretName));
+        Secret tlsCert = clusterUser.create(tlsKeyAndCertSecret(downstreamCertSecretName));
 
         Ingresses clusterIngress = createIngressForCluster(openshiftRouteIngress, tlsCert);
         VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress), Optional.empty());
 
         // When
-        updateStatusObservedGeneration(operator.create(cluster));
+        updateStatusObservedGeneration(clusterUser.create(cluster));
 
         // Then
         String serviceName = name(cluster) + "-" + name(openshiftRouteIngress) + "-service";
         AWAIT.alias("shared sni service manifested").untilAsserted(() -> {
-            var service = operator.get(Service.class, serviceName);
+            var service = clusterUser.get(Service.class, serviceName);
             assertThat(service).isNotNull()
                     .describedAs(
                             "Expect shared SNI Service for proxy '" + name(proxy) + " to exist")
@@ -928,15 +937,15 @@ public class KafkaProxyReconcilerIT {
                 .withFailMessage("kubernetes server is missing support for resource kind Route").isTrue();
 
         // Given
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
         KafkaService kafkaService = updateStatusObservedGeneration(
-                operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+                clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
         String ingressName = "openshiftroute";
         KafkaProxyIngress openshiftRouteIngress = updateStatusObservedGeneration(
-                operator.create(openshiftRouteIngress(ingressName, proxy)));
+                clusterUser.create(openshiftRouteIngress(ingressName, proxy)));
 
-        Secret tlsCert = operator.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
+        Secret tlsCert = clusterUser.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
 
         Ingresses clusterIngress = new IngressesBuilder()
                 .withIngressRef(toIngressRef(openshiftRouteIngress))
@@ -944,15 +953,15 @@ public class KafkaProxyReconcilerIT {
                 .build();
         VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService,
                 List.of(clusterIngress), Optional.empty());
-        updateStatusObservedGeneration(operator.create(cluster));
+        updateStatusObservedGeneration(clusterUser.create(cluster));
 
         String bootstrapRouteName = name(cluster) + "-bootstrap";
-        AWAIT.alias("bootstrap route created").untilAsserted(() -> assertThat(operator.get(Route.class, bootstrapRouteName)).isNotNull());
+        AWAIT.alias("bootstrap route created").untilAsserted(() -> assertThat(clusterUser.get(Route.class, bootstrapRouteName)).isNotNull());
 
         String initialChecksum = deploymentPodTemplateChecksum(proxy);
 
         // When - OpenShift assigns a host to the bootstrap route
-        Route bootstrapRoute = operator.get(Route.class, bootstrapRouteName);
+        Route bootstrapRoute = clusterUser.get(Route.class, bootstrapRouteName);
         Route routeWithHost = new RouteBuilder(bootstrapRoute)
                 .withNewStatus()
                 .addNewIngress().withHost(bootstrapRouteName + ".apps-crc.testing").endIngress()
@@ -966,7 +975,7 @@ public class KafkaProxyReconcilerIT {
     }
 
     private String deploymentPodTemplateChecksum(KafkaProxy proxy) {
-        var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+        var deployment = clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
         assertThat(deployment).isNotNull();
         return Optional.ofNullable(deployment.getSpec().getTemplate().getMetadata().getAnnotations())
                 .map(annotations -> annotations.get(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY))
@@ -974,7 +983,7 @@ public class KafkaProxyReconcilerIT {
     }
 
     private void assertRouteManifested(String routeName, boolean isBootstrap, KafkaProxy proxy, String serviceName, int targetPort) {
-        var openshiftRoute = operator.get(Route.class, routeName);
+        var openshiftRoute = clusterUser.get(Route.class, routeName);
         assertThat(openshiftRoute).isNotNull()
                 .describedAs(
                         "Expect Route for proxy '" + name(proxy) + " to exist")
@@ -1045,15 +1054,15 @@ public class KafkaProxyReconcilerIT {
     }
 
     CreatedResources doCreate(KafkaService kafkaService, KafkaProxy kafkaProxy) {
-        KafkaProxy proxy = operator.create(kafkaProxy);
-        KafkaProtocolFilter filter = operator.create(filter(FILTER_NAME));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy);
+        KafkaProtocolFilter filter = clusterUser.create(filter(FILTER_NAME));
         filter = updateStatusObservedGeneration(filter);
-        KafkaService barService = operator.create(kafkaService);
+        KafkaService barService = clusterUser.create(kafkaService);
         barService = updateStatusObservedGeneration(barService, CLUSTER_BAR_BOOTSTRAP);
-        KafkaProxyIngress ingressBar = operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TCP));
+        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TCP));
         ingressBar = updateStatusObservedGeneration(ingressBar);
         Set<KafkaService> kafkaServices = Set.of(barService);
-        VirtualKafkaCluster clusterBar = operator.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barService,
+        VirtualKafkaCluster clusterBar = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressBar)).build()), Optional.of(filter)));
         clusterBar = updateStatusObservedGeneration(clusterBar);
         Set<VirtualKafkaCluster> clusters = Set.of(clusterBar);
@@ -1077,7 +1086,7 @@ public class KafkaProxyReconcilerIT {
     }
 
     private ProxyConfigAssert assertProxyConfigInConfigMap(KafkaProxy proxy) {
-        var configMap = operator.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
+        var configMap = clusterUser.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
         return assertThat(configMap)
                 .isNotNull()
                 .extracting(ConfigMap::getData, InstanceOfAssertFactories.map(String.class, String.class))
@@ -1199,7 +1208,7 @@ public class KafkaProxyReconcilerIT {
     private void assertDeploymentBecomesReady(KafkaProxy proxy) {
         // wait longer for initial operator image download
         AWAIT.alias("Deployment as expected").untilAsserted(() -> {
-            var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+            var deployment = clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
             assertThat(deployment)
                     .describedAs("All deployment replicas should become ready")
                     .returns(true, Readiness::isDeploymentReady);
@@ -1211,7 +1220,7 @@ public class KafkaProxyReconcilerIT {
             String clusterName = name(cluster);
             String ingressName = name(ingress);
             String serviceName = clusterName + "-" + ingressName + "-bootstrap";
-            var service = operator.get(Service.class, serviceName);
+            var service = clusterUser.get(Service.class, serviceName);
             assertThat(service).isNotNull()
                     .describedAs(
                             "Expect Service for cluster '" + clusterName + "' and ingress '" + ingressName + "' to still exist")
@@ -1236,7 +1245,7 @@ public class KafkaProxyReconcilerIT {
 
     private <T> void assertDeploymentMounts(KafkaProxy proxy, Function<Volume, T> volumeSourceExtractor, Predicate<T> volumeSourcePredicate) {
         AWAIT.alias("Deployment as expected").untilAsserted(() -> {
-            var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+            var deployment = clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
             assertThat(deployment).isNotNull()
                     .extracting(dep -> dep.getSpec().getTemplate().getSpec().getVolumes(), InstanceOfAssertFactories.list(Volume.class))
                     .describedAs("Deployment template should mount the proxy config configmap")
@@ -1248,7 +1257,7 @@ public class KafkaProxyReconcilerIT {
 
     private Deployment assertDeploymentReplicaCount(KafkaProxy proxy, int expectedReplicaCount) {
         AtomicReference<Deployment> actualDeployment = new AtomicReference<>();
-        AWAIT.alias("Deployment as expected").untilAsserted(() -> operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy)),
+        AWAIT.alias("Deployment as expected").untilAsserted(() -> clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy)),
                 deployment -> {
                     assertThat(deployment).isNotNull();
                     assertThat(deployment.getSpec())
@@ -1260,7 +1269,7 @@ public class KafkaProxyReconcilerIT {
     }
 
     private void assertDeploymentResourcesEqual(KafkaProxy proxy, ResourceRequirements resourceRequirements) {
-        AWAIT.alias("Deployment as expected").untilAsserted(() -> operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy)),
+        AWAIT.alias("Deployment as expected").untilAsserted(() -> clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy)),
                 deployment -> {
                     assertThat(deployment).isNotNull();
                     assertThat(deployment.getSpec())
@@ -1273,7 +1282,7 @@ public class KafkaProxyReconcilerIT {
 
     private void assertStausReplicaCount(KafkaProxy proxy, int expectedReplicaCount) {
         AWAIT.alias("Deployment as expected").untilAsserted(() -> {
-            var deployment = operator.get(KafkaProxy.class, ResourcesUtil.name(proxy));
+            var deployment = clusterUser.get(KafkaProxy.class, ResourcesUtil.name(proxy));
             assertThat(deployment).isNotNull()
                     .extracting(KafkaProxy::getStatus, AssertFactory.status())
                     .isNotNull()
@@ -1297,19 +1306,19 @@ public class KafkaProxyReconcilerIT {
     void testDelete() {
         var createdResources = doCreate();
         KafkaProxy proxy = createdResources.proxy;
-        operator.delete(proxy);
+        clusterUser.delete(proxy);
 
         AWAIT.alias("ConfigMap was deleted").untilAsserted(() -> {
-            var configMap = operator.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
+            var configMap = clusterUser.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
             assertThat(configMap).isNull();
         });
         AWAIT.alias("Deployment was deleted").untilAsserted(() -> {
-            var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+            var deployment = clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
             assertThat(deployment).isNull();
         });
         AWAIT.alias("Services were deleted").untilAsserted(() -> {
             for (var cluster : createdResources.clusters) {
-                var service = operator.get(Service.class, ClusterServiceDependentResource.serviceName(cluster));
+                var service = clusterUser.get(Service.class, ClusterServiceDependentResource.serviceName(cluster));
                 assertThat(service).isNull();
             }
         });
@@ -1320,7 +1329,7 @@ public class KafkaProxyReconcilerIT {
         final var createdResources = doCreate();
         KafkaProxy proxy = createdResources.proxy;
         var kafkaService = createdResources.kafkaService().edit().editSpec().withBootstrapServers(NEW_BOOTSTRAP).endSpec().build();
-        kafkaService = operator.replace(kafkaService);
+        kafkaService = clusterUser.replace(kafkaService);
         updateStatusObservedGeneration(kafkaService, NEW_BOOTSTRAP);
 
         assertDeploymentBecomesReady(proxy);
@@ -1338,13 +1347,13 @@ public class KafkaProxyReconcilerIT {
         KafkaProxy proxy = createdResources.proxy;
 
         String newClusterRefName = "new-cluster-ref";
-        updateStatusObservedGeneration(operator.create(kafkaService(newClusterRefName, NEW_BOOTSTRAP)), NEW_BOOTSTRAP);
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(newClusterRefName, NEW_BOOTSTRAP)), NEW_BOOTSTRAP);
 
         KafkaServiceRef newClusterRef = new KafkaServiceRefBuilder().withName(newClusterRefName).build();
         var cluster = createdResources.cluster().edit().editSpec().withTargetKafkaServiceRef(newClusterRef).endSpec().build();
 
         // when
-        cluster = operator.replace(cluster);
+        cluster = clusterUser.replace(cluster);
         updateStatusObservedGeneration(cluster);
 
         // then
@@ -1360,15 +1369,15 @@ public class KafkaProxyReconcilerIT {
     void testDeleteVirtualCluster() {
         final var createdResources = doCreate();
         KafkaProxy proxy = createdResources.proxy;
-        operator.delete(createdResources.cluster());
+        clusterUser.delete(createdResources.cluster());
 
         AWAIT.untilAsserted(() -> {
-            var configMap = operator.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
+            var configMap = clusterUser.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
             assertThat(configMap)
                     .describedAs("Expect ConfigMap for cluster 'bar' to have been deleted")
                     .isNull();
 
-            var service = operator.get(Service.class, CLUSTER_BAR);
+            var service = clusterUser.get(Service.class, CLUSTER_BAR);
             assertThat(service)
                     .describedAs("Expect Service for cluster 'bar' to have been deleted")
                     .isNull();
@@ -1378,19 +1387,19 @@ public class KafkaProxyReconcilerIT {
     @Test
     void moveVirtualKafkaClusterToAnotherKafkaProxy() {
         // given
-        KafkaProxy proxyA = operator.create(kafkaProxy(PROXY_A));
-        KafkaProxy proxyB = operator.create(kafkaProxy(PROXY_B));
-        KafkaProxyIngress ingressFoo = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyA, TCP)));
-        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxyB, TCP)));
+        KafkaProxy proxyA = clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxyB = clusterUser.create(kafkaProxy(PROXY_B));
+        KafkaProxyIngress ingressFoo = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyA, TCP)));
+        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxyB, TCP)));
 
-        KafkaService fooService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)), CLUSTER_FOO_BOOTSTRAP);
-        KafkaService barService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
-        KafkaProtocolFilter filter = updateStatusObservedGeneration(operator.create(filter(FILTER_NAME)));
+        KafkaService fooService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)), CLUSTER_FOO_BOOTSTRAP);
+        KafkaService barService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaProtocolFilter filter = updateStatusObservedGeneration(clusterUser.create(filter(FILTER_NAME)));
 
-        VirtualKafkaCluster fooCluster = operator.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooService,
+        VirtualKafkaCluster fooCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressFoo)).build()), Optional.of(filter)));
         updateStatusObservedGeneration(fooCluster);
-        VirtualKafkaCluster barCluster = operator.create(virtualKafkaCluster(CLUSTER_BAR, proxyB, barService,
+        VirtualKafkaCluster barCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR, proxyB, barService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressBar)).build()), Optional.of(filter)));
         updateStatusObservedGeneration(barCluster);
 
@@ -1400,17 +1409,17 @@ public class KafkaProxyReconcilerIT {
         assertServiceTargetsProxyInstances(proxyB, barCluster, ingressBar);
 
         // must swap ingresses so both proxy instances have a single port-per-broker ingress
-        updateStatusObservedGeneration(operator.replace(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyB, TCP)));
-        updateStatusObservedGeneration(operator.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxyA, TCP)));
-        var updatedFooCluster = new VirtualKafkaClusterBuilder(operator.get(VirtualKafkaCluster.class, CLUSTER_FOO)).editSpec().editProxyRef().withName(name(proxyB))
+        updateStatusObservedGeneration(clusterUser.replace(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyB, TCP)));
+        updateStatusObservedGeneration(clusterUser.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxyA, TCP)));
+        var updatedFooCluster = new VirtualKafkaClusterBuilder(clusterUser.get(VirtualKafkaCluster.class, CLUSTER_FOO)).editSpec().editProxyRef().withName(name(proxyB))
                 .endProxyRef().endSpec()
                 .build();
-        updatedFooCluster = operator.replace(updatedFooCluster);
+        updatedFooCluster = clusterUser.replace(updatedFooCluster);
         updateStatusObservedGeneration(updatedFooCluster);
-        var updatedBarCluster = new VirtualKafkaClusterBuilder(operator.get(VirtualKafkaCluster.class, CLUSTER_BAR)).editSpec().editProxyRef().withName(name(proxyA))
+        var updatedBarCluster = new VirtualKafkaClusterBuilder(clusterUser.get(VirtualKafkaCluster.class, CLUSTER_BAR)).editSpec().editProxyRef().withName(name(proxyA))
                 .endProxyRef().endSpec()
                 .build();
-        updatedBarCluster = operator.replace(updatedBarCluster);
+        updatedBarCluster = clusterUser.replace(updatedBarCluster);
         updateStatusObservedGeneration(updatedBarCluster);
 
         // then
@@ -1427,30 +1436,30 @@ public class KafkaProxyReconcilerIT {
     @Test
     void deleteAndRestoreADependency() {
         // given
-        KafkaProxy proxyA = operator.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxyA = clusterUser.create(kafkaProxy(PROXY_A));
 
         KafkaProxyIngress ingress = clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyA, TCP);
-        KafkaProxyIngress ingressFoo = updateStatusObservedGeneration(operator.create(ingress.edit().build()));
+        KafkaProxyIngress ingressFoo = updateStatusObservedGeneration(clusterUser.create(ingress.edit().build()));
 
-        KafkaService fooService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)), CLUSTER_FOO_BOOTSTRAP);
-        KafkaProtocolFilter filter = updateStatusObservedGeneration(operator.create(filter(FILTER_NAME)));
+        KafkaService fooService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)), CLUSTER_FOO_BOOTSTRAP);
+        KafkaProtocolFilter filter = updateStatusObservedGeneration(clusterUser.create(filter(FILTER_NAME)));
 
         VirtualKafkaCluster fooCluster = updateStatusObservedGeneration(
-                operator.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooService, List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressFoo)).build()),
+                clusterUser.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooService, List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressFoo)).build()),
                         Optional.of(filter))));
 
         assertProxyConfigContents(proxyA, Set.of(CLUSTER_FOO_BOOTSTRAP), Set.of());
         assertServiceTargetsProxyInstances(proxyA, fooCluster, ingressFoo);
 
         // when
-        operator.delete(ingressFoo);
+        clusterUser.delete(ingressFoo);
 
         // then
         assertDeploymentIsRemoved(proxyA);
 
         // and when
         // we need an ingress without uid/resourceVersion in its metadata, so we clone an unadulterated ingress
-        updateStatusObservedGeneration(operator.create(ingress.edit().build()));
+        updateStatusObservedGeneration(clusterUser.create(ingress.edit().build()));
 
         // and then
         assertDeploymentBecomesReady(proxyA);
@@ -1489,11 +1498,11 @@ public class KafkaProxyReconcilerIT {
     private void assertDeploymentIsRemoved(KafkaProxy proxy) {
         // wait longer for initial operator image download
         AWAIT.alias("Deployment is removed")
-                .untilAsserted(() -> assertThat(operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy))).isNull());
+                .untilAsserted(() -> assertThat(clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy))).isNull());
     }
 
     private AbstractStringAssert<?> assertThatProxyConfigFor(KafkaProxy proxy) {
-        var configMap = operator.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
+        var configMap = clusterUser.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
         return assertThat(configMap)
                 .isNotNull()
                 .extracting(ConfigMap::getData, InstanceOfAssertFactories.map(String.class, String.class))

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconcilerIT.java
@@ -10,6 +10,7 @@ import java.time.Clock;
 import java.time.Duration;
 
 import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -19,6 +20,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
+import io.kroxylicious.kubernetes.operator.ClusterUser;
 import io.kroxylicious.kubernetes.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.assertj.KafkaProxyIngressStatusAssert;
@@ -42,39 +44,46 @@ class KafkaProxyIngressReconcilerIT {
             .replaceClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
             .build();
 
+    private ClusterUser clusterUser;
+
+    @BeforeEach
+    void setUp() {
+        clusterUser = operator.clusterUser();
+    }
+
     @Test
     void testCreateIngressFirst() {
-        KafkaProxyIngress ingressBar = operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertResolvedRefsFalse(ingressBar);
-        operator.create(kafkaProxy(PROXY_A));
+        clusterUser.create(kafkaProxy(PROXY_A));
         assertAllConditionsTrue(ingressBar);
     }
 
     @Test
     void testCreateProxyFirst() {
-        operator.create(kafkaProxy(PROXY_A));
-        KafkaProxyIngress ingressBar = operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertAllConditionsTrue(ingressBar);
     }
 
     @Test
     void testDeleteProxy() {
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
-        KafkaProxyIngress ingressBar = operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertAllConditionsTrue(ingressBar);
 
-        operator.delete(proxy);
+        clusterUser.delete(proxy);
         assertResolvedRefsFalse(ingressBar);
     }
 
     @Test
     void testSwitchProxy() {
-        operator.create(kafkaProxy(PROXY_A));
-        operator.create(kafkaProxy(PROXY_B));
-        KafkaProxyIngress ingressBar = operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        clusterUser.create(kafkaProxy(PROXY_A));
+        clusterUser.create(kafkaProxy(PROXY_B));
+        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertAllConditionsTrue(ingressBar);
 
-        operator.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_B));
+        clusterUser.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_B));
         assertAllConditionsTrue(ingressBar);
     }
 
@@ -86,7 +95,7 @@ class KafkaProxyIngressReconcilerIT {
 
     private void assertAllConditionsTrue(KafkaProxyIngress ingressBar) {
         AWAIT.alias("IngressStatusConditionsAllTrue").untilAsserted(() -> {
-            var kpi = operator.resources(KafkaProxyIngress.class)
+            var kpi = clusterUser.resources(KafkaProxyIngress.class)
                     .withName(ResourcesUtil.name(ingressBar)).get();
             assertThat(kpi.getStatus()).isNotNull();
             var conditionListAssert = KafkaProxyIngressStatusAssert
@@ -106,7 +115,7 @@ class KafkaProxyIngressReconcilerIT {
 
     private void assertResolvedRefsFalse(KafkaProxyIngress cr) {
         AWAIT.alias("IngressStatusResolvedRefs").untilAsserted(() -> {
-            var kpi = operator.resources(KafkaProxyIngress.class)
+            var kpi = clusterUser.resources(KafkaProxyIngress.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(kpi.getStatus()).isNotNull();
             KafkaProxyIngressStatusAssert

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
@@ -11,6 +11,7 @@ import java.time.Duration;
 
 import org.assertj.core.api.Assertions;
 import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -24,6 +25,7 @@ import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
 import io.kroxylicious.kubernetes.operator.Annotations;
+import io.kroxylicious.kubernetes.operator.ClusterUser;
 import io.kroxylicious.kubernetes.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions;
@@ -52,13 +54,20 @@ class KafkaServiceBootstrapReconcilerIT {
             .replaceClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
             .build();
 
+    private ClusterUser clusterUser;
+
+    @BeforeEach
+    void setUp() {
+        clusterUser = operator.clusterUser();
+    }
+
     @Test
     void shouldImmediatelyResolveWhenNoReferents() {
         // Given
         KafkaService resource = kafkaService(SERVICE_A, null, null, null);
 
         // When
-        operator.create(resource);
+        clusterUser.create(resource);
 
         // Then
         assertResolvedRefsTrue(resource, FOO_BOOTSTRAP_9090, false);
@@ -67,12 +76,12 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldResolveUpdateToKafkaService() {
         // Given
-        var kafkaService = operator.create(
+        var kafkaService = clusterUser.create(
                 new KafkaServiceBuilder().withNewMetadata().withName(SERVICE_A).endMetadata().withNewSpec().withBootstrapServers(FOO_BOOTSTRAP_9090).endSpec().build());
 
         // When
         final KafkaService updated = kafkaService.edit().editSpec().withBootstrapServers(BAR_BOOTSTRAP_9090).endSpec().build();
-        operator.replace(updated);
+        clusterUser.replace(updated);
 
         // Then
         assertResolvedRefsTrue(updated, BAR_BOOTSTRAP_9090, false);
@@ -84,13 +93,13 @@ class KafkaServiceBootstrapReconcilerIT {
         KafkaService resource = kafkaService(SERVICE_A, SECRET_X, null, null);
 
         // When
-        final KafkaService kafkaService = operator.create(resource);
+        final KafkaService kafkaService = clusterUser.create(resource);
 
         // Then
         assertResolvedRefsFalse(kafkaService, Condition.REASON_REFS_NOT_FOUND, "spec.tls.certificateRef: referenced secret not found");
 
         // And When
-        operator.create(tlsCertificateSecret(SECRET_X));
+        clusterUser.create(tlsCertificateSecret(SECRET_X));
 
         // Then
         assertResolvedRefsTrue(kafkaService, FOO_BOOTSTRAP_9090, true);
@@ -100,8 +109,8 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateStatusOnceTlsCertificateSecretDeleted() {
         // Given
-        var tlsCertSecret = operator.create(tlsCertificateSecret(SECRET_X));
-        KafkaService resource = operator.create(kafkaService(SERVICE_A, SECRET_X, null, null));
+        var tlsCertSecret = clusterUser.create(tlsCertificateSecret(SECRET_X));
+        KafkaService resource = clusterUser.create(kafkaService(SERVICE_A, SECRET_X, null, null));
         assertResolvedRefsTrue(resource, FOO_BOOTSTRAP_9090, true);
 
         // When
@@ -117,13 +126,13 @@ class KafkaServiceBootstrapReconcilerIT {
         KafkaService resource = kafkaService(SERVICE_A, null, CONFIG_MAP_T, null);
 
         // When
-        final KafkaService kafkaService = operator.create(resource);
+        final KafkaService kafkaService = clusterUser.create(resource);
 
         // Then
         assertResolvedRefsFalse(kafkaService, Condition.REASON_REFS_NOT_FOUND, "spec.tls.trustAnchorRef: referenced configmap not found");
 
         // And When
-        operator.create(trustAnchorConfigMap(CONFIG_MAP_T));
+        clusterUser.create(trustAnchorConfigMap(CONFIG_MAP_T));
 
         // Then
         assertResolvedRefsTrue(kafkaService, FOO_BOOTSTRAP_9090, true);
@@ -136,13 +145,13 @@ class KafkaServiceBootstrapReconcilerIT {
         KafkaService resource = kafkaService(SERVICE_A, null, SECRET_T, "Secret");
 
         // When
-        final KafkaService kafkaService = operator.create(resource);
+        final KafkaService kafkaService = clusterUser.create(resource);
 
         // Then
         assertResolvedRefsFalse(kafkaService, Condition.REASON_REFS_NOT_FOUND, "spec.tls.trustAnchorRef: referenced secret not found");
 
         // And When
-        operator.create(trustAnchorSecret(SECRET_T));
+        clusterUser.create(trustAnchorSecret(SECRET_T));
 
         // Then
         assertResolvedRefsTrue(kafkaService, FOO_BOOTSTRAP_9090, true);
@@ -152,13 +161,13 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateReferentAnnotationWhenTrustAnchorConfigMapModified() {
         // Given
-        operator.create(trustAnchorConfigMap(CONFIG_MAP_T));
+        clusterUser.create(trustAnchorConfigMap(CONFIG_MAP_T));
         KafkaService resource = kafkaService(SERVICE_A, null, CONFIG_MAP_T, null);
-        final KafkaService kafkaService = operator.create(resource);
+        final KafkaService kafkaService = clusterUser.create(resource);
         String checksum = awaitReferentsChecksumSpecified(resource);
 
         // When
-        operator.replace(trustAnchorConfigMap(CONFIG_MAP_T).edit().addToData("arbitrary", "arbitrary").build());
+        clusterUser.replace(trustAnchorConfigMap(CONFIG_MAP_T).edit().addToData("arbitrary", "arbitrary").build());
 
         // Then
         assertReferentsChecksumNotEqual(kafkaService, checksum);
@@ -167,12 +176,12 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateReferentAnnotationWhenCertificateSecretModified() {
         // Given
-        operator.create(tlsCertificateSecret(SECRET_X));
-        KafkaService resource = operator.create(kafkaService(SERVICE_A, SECRET_X, null, null));
+        clusterUser.create(tlsCertificateSecret(SECRET_X));
+        KafkaService resource = clusterUser.create(kafkaService(SERVICE_A, SECRET_X, null, null));
         String checksum = awaitReferentsChecksumSpecified(resource);
 
         // When
-        operator.replace(tlsCertificateSecret(SECRET_X).edit().addToData("arbitrary", "whatever").build());
+        clusterUser.replace(tlsCertificateSecret(SECRET_X).edit().addToData("arbitrary", "whatever").build());
 
         // Then
         assertReferentsChecksumNotEqual(resource, checksum);
@@ -181,8 +190,8 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateStatusOnceTrustAnchorConfigMapDeleted() {
         // Given
-        var trustedCaCerts = operator.create(trustAnchorConfigMap(CONFIG_MAP_T));
-        KafkaService resource = operator.create(kafkaService(SERVICE_A, null, CONFIG_MAP_T, null));
+        var trustedCaCerts = clusterUser.create(trustAnchorConfigMap(CONFIG_MAP_T));
+        KafkaService resource = clusterUser.create(kafkaService(SERVICE_A, null, CONFIG_MAP_T, null));
         assertResolvedRefsTrue(resource, FOO_BOOTSTRAP_9090, true);
 
         // When
@@ -269,7 +278,7 @@ class KafkaServiceBootstrapReconcilerIT {
 
     private void assertResolvedRefsTrue(KafkaService cr, String expectedBootstrap, boolean hasReferents) {
         AWAIT.untilAsserted(() -> {
-            final KafkaService kafkaService = operator.get(KafkaService.class, ResourcesUtil.name(cr));
+            final KafkaService kafkaService = clusterUser.get(KafkaService.class, ResourcesUtil.name(cr));
             Assertions.assertThat(kafkaService).isNotNull();
             Assertions.assertThat(kafkaService.getStatus().getBootstrapServers()).isEqualTo(expectedBootstrap);
             assertThat(kafkaService.getStatus())
@@ -289,14 +298,14 @@ class KafkaServiceBootstrapReconcilerIT {
 
     private String awaitReferentsChecksumSpecified(KafkaService cr) {
         return AWAIT.until(() -> {
-            final KafkaService kafkaService = operator.get(KafkaService.class, ResourcesUtil.name(cr));
+            final KafkaService kafkaService = clusterUser.get(KafkaService.class, ResourcesUtil.name(cr));
             return getReferentChecksum(kafkaService);
         }, s -> !s.equals(NO_CHECKSUM_SPECIFIED));
     }
 
     private void assertReferentsChecksumNotEqual(KafkaService cr, String checksum) {
         AWAIT.untilAsserted(() -> {
-            final KafkaService kafkaService = operator.get(KafkaService.class, ResourcesUtil.name(cr));
+            final KafkaService kafkaService = clusterUser.get(KafkaService.class, ResourcesUtil.name(cr));
             String actualChecksum = getReferentChecksum(kafkaService);
             Assertions.assertThat(actualChecksum).isNotEqualTo(checksum);
         });
@@ -311,7 +320,7 @@ class KafkaServiceBootstrapReconcilerIT {
                                          String reason,
                                          String message) {
         AWAIT.alias("KafkaServiceStatusResolvedRefs").untilAsserted(() -> {
-            var kafkaService = operator.resources(KafkaService.class)
+            var kafkaService = clusterUser.resources(KafkaService.class)
                     .withName(ResourcesUtil.name(cr)).get();
             Assertions.assertThat(kafkaService.getStatus()).isNotNull();
             OperatorAssertions

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
@@ -114,7 +114,7 @@ class KafkaServiceBootstrapReconcilerIT {
         assertResolvedRefsTrue(resource, FOO_BOOTSTRAP_9090, true);
 
         // When
-        operator.delete(tlsCertSecret);
+        clusterUser.delete(tlsCertSecret);
 
         // Then
         assertResolvedRefsFalse(resource, Condition.REASON_REFS_NOT_FOUND, "spec.tls.certificateRef: referenced secret not found");
@@ -195,7 +195,7 @@ class KafkaServiceBootstrapReconcilerIT {
         assertResolvedRefsTrue(resource, FOO_BOOTSTRAP_9090, true);
 
         // When
-        operator.delete(trustedCaCerts);
+        clusterUser.delete(trustedCaCerts);
 
         // Then
         assertResolvedRefsFalse(resource, Condition.REASON_REFS_NOT_FOUND, "spec.tls.trustAnchorRef: referenced configmap not found");

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.assertj.core.api.Assertions;
 import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -29,6 +30,7 @@ import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
 import io.kroxylicious.kubernetes.operator.Annotations;
+import io.kroxylicious.kubernetes.operator.ClusterUser;
 import io.kroxylicious.kubernetes.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.kubernetes.operator.OperatorTestUtils;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
@@ -67,10 +69,17 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
             .withAdditionalCleanupTypes(Kafka.class)
             .build();
 
+    private ClusterUser clusterUser;
+
+    @BeforeEach
+    void setUp() {
+        clusterUser = operator.clusterUser();
+    }
+
     @Test
     void shouldResolveStrimziKafka() {
         // Given
-        var kafka = operator.create(kafkaResource(KAFKA_RESOURCE_NAME));
+        var kafka = clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME));
         String listenerHost = "foo.bootstrap";
         int listenerPort = 9090;
         Kafka withStatus = new KafkaBuilder(kafka)
@@ -88,7 +97,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
         operator.patchStatus(withStatus);
 
         // When
-        KafkaService service = operator.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
 
         // Then
         assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
@@ -123,10 +132,10 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
                 .endStatus()
                 .build();
 
-        operator.create(withTlsListener);
+        clusterUser.create(withTlsListener);
 
         // When
-        KafkaService service = operator.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "tls", KAFKA_RESOURCE_NAME));
+        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "tls", KAFKA_RESOURCE_NAME));
 
         // Then
         assertResolvedRefsFalse(service, Condition.REASON_INVALID_REFERENCED_RESOURCE, "Referenced resource should have listener as `plain`");
@@ -135,7 +144,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void shouldHandleStrimziKafkaWithNoListeners() {
         // Given
-        var kafka = operator.create(kafkaResource(KAFKA_RESOURCE_NAME));
+        var kafka = clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME));
 
         Kafka withNoListener = new KafkaBuilder(kafka)
                 .withNewStatus()
@@ -145,7 +154,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
         operator.patchStatus(withNoListener);
 
         // When
-        KafkaService service = operator.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
 
         // Then
         assertResolvedRefsFalse(service, Condition.REASON_REFERENCED_RESOURCE_NOT_RECONCILED, "Referenced resource has not yet reconciled listener name: plain");
@@ -154,11 +163,11 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void shouldHandleStrimziKafkaWithNoStatus() {
         // Given
-        operator.create(kafkaResource(KAFKA_RESOURCE_NAME));
+        clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME));
 
         // When
 
-        KafkaService service = operator.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
 
         // Then
         assertResolvedRefsFalse(service, Condition.REASON_REFERENCED_RESOURCE_NOT_RECONCILED, "Referenced resource has not yet reconciled listener name: plain");
@@ -167,7 +176,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void shouldUpdateStatusOnceStrimziKafkaResourceDeleted() {
         // Given
-        var kafka = operator.create(kafkaResource(KAFKA_RESOURCE_NAME));
+        var kafka = clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME));
         String listenerHost = "foo.bootstrap";
         int listenerPort = 9090;
         Kafka withListeners = new KafkaBuilder(kafka)
@@ -185,7 +194,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
         operator.patchStatus(withListeners);
 
         // When
-        KafkaService updated = operator.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+        KafkaService updated = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
         assertResolvedRefsTrue(updated, FOO_BOOTSTRAP_9090, true);
 
         // When
@@ -233,7 +242,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
 
     private void assertResolvedRefsTrue(KafkaService cr, String expectedBootstrap, boolean hasReferents) {
         AWAIT.untilAsserted(() -> {
-            final KafkaService kafkaService = operator.get(KafkaService.class, ResourcesUtil.name(cr));
+            final KafkaService kafkaService = clusterUser.get(KafkaService.class, ResourcesUtil.name(cr));
             Assertions.assertThat(kafkaService).isNotNull();
             Assertions.assertThat(kafkaService.getStatus().getBootstrapServers()).isEqualTo(expectedBootstrap);
             assertThat(kafkaService.getStatus())
@@ -260,7 +269,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
                                          String reason,
                                          String message) {
         AWAIT.alias("KafkaServiceStatusResolvedRefs").untilAsserted(() -> {
-            var kafkaService = operator.resources(KafkaService.class)
+            var kafkaService = clusterUser.resources(KafkaService.class)
                     .withName(ResourcesUtil.name(cr)).get();
             Assertions.assertThat(kafkaService.getStatus()).isNotNull();
             OperatorAssertions

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
@@ -198,7 +198,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
         assertResolvedRefsTrue(updated, FOO_BOOTSTRAP_9090, true);
 
         // When
-        operator.delete(kafka);
+        clusterUser.delete(kafka);
 
         // Then
         assertResolvedRefsFalse(updated, Condition.REASON_REFS_NOT_FOUND, "spec.strimziKafkaRef: referenced Kafka resource not found");

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
@@ -193,7 +193,7 @@ class VirtualKafkaClusterReconcilerIT {
         assertAllConditionsTrue(clusterBar);
 
         // When
-        operator.delete((HasMetadata) proxy);
+        clusterUser.delete((HasMetadata) proxy);
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
@@ -210,7 +210,7 @@ class VirtualKafkaClusterReconcilerIT {
         assertAllConditionsTrue(clusterBar);
 
         // When
-        operator.delete(filter);
+        clusterUser.delete(filter);
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -39,6 +40,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressesBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterstatus.Ingresses;
+import io.kroxylicious.kubernetes.operator.ClusterUser;
 import io.kroxylicious.kubernetes.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
@@ -80,16 +82,23 @@ class VirtualKafkaClusterReconcilerIT {
             .replaceClusterRoleGlobs("*.ClusterRole*.yaml")
             .build();
 
+    private ClusterUser clusterUser;
+
+    @BeforeEach
+    void setUp() {
+        clusterUser = operator.clusterUser();
+    }
+
     @Test
     void shouldResolveWhenClusterCreatedAfterReferents() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(operator.create(filter(FILTER_K)));
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K)));
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -98,17 +107,17 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileProxyInitiallyAbsent() {
         // Given
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null));
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null));
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        operator.create(kafkaProxy(PROXY_A));
+        clusterUser.create(kafkaProxy(PROXY_A));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -117,17 +126,17 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileServiceInitiallyAbsent() {
         // Given
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        operator.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        clusterUser.create(kafkaProxy(PROXY_A));
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null));
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null));
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -136,18 +145,18 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileIngressInitiallyAbsent() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
 
         // When
         VirtualKafkaCluster resource = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
-        VirtualKafkaCluster clusterBar = operator.create(resource);
+        VirtualKafkaCluster clusterBar = clusterUser.create(resource);
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -156,18 +165,18 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileFilterInitiallyAbsent() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        updateStatusObservedGeneration(operator.create(filter(FILTER_K)));
+        updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K)));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -176,11 +185,11 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhenProxyDeleted() {
         // Given
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(operator.create(filter(FILTER_K)));
-        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K)));
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
         assertAllConditionsTrue(clusterBar);
 
         // When
@@ -193,11 +202,11 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhenFilterDeleted() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        var filter = updateStatusObservedGeneration(operator.create(filter(FILTER_K)));
-        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        var filter = updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K)));
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
         assertAllConditionsTrue(clusterBar);
 
         // When
@@ -210,20 +219,20 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileIngressRefersToOtherProxy() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        operator.create(kafkaProxy(PROXY_B));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_B, TCP))); // not A, which is what the VKC references
+        clusterUser.create(kafkaProxy(PROXY_A));
+        clusterUser.create(kafkaProxy(PROXY_B));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_B, TCP))); // not A, which is what the VKC references
 
         // When
         VirtualKafkaCluster resource = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
-        VirtualKafkaCluster clusterBar = operator.create(resource);
+        VirtualKafkaCluster clusterBar = clusterUser.create(resource);
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_TRANSITIVE_REFS_NOT_FOUND);
 
         // And when
-        updateStatusObservedGeneration(operator.replace(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.replace(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -232,20 +241,20 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileTwoIpIngresses() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_E, PROXY_A, TCP)));
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_E, PROXY_A, TCP)));
 
         // When
         VirtualKafkaCluster resource = cluster(CLUSTER_BAR, PROXY_A, List.of(INGRESS_D, INGRESS_E), SERVICE_H, null);
-        VirtualKafkaCluster clusterBar = operator.create(resource);
+        VirtualKafkaCluster clusterBar = clusterUser.create(resource);
 
         // Then
         assertClusterAcceptedFalse(clusterBar, ProxyConfigDependentResource.REASON_INVALID);
 
         // And when
-        operator.replace(cluster(CLUSTER_BAR, PROXY_A, List.of(INGRESS_D), SERVICE_H, null));
+        clusterUser.replace(cluster(CLUSTER_BAR, PROXY_A, List.of(INGRESS_D), SERVICE_H, null));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -254,14 +263,14 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldReportIngressClusterIpBootstrap() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
         var cluster = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
         var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TCP);
-        updateStatusObservedGeneration(operator.create(ingress));
+        updateStatusObservedGeneration(clusterUser.create(ingress));
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster);
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster);
 
         // Then
         assertClusterIngressStatusPopulated(clusterBar, ingress, "bar-cluster-ingress-d-bootstrap.%s.svc.cluster.local:9292", Protocol.TCP);
@@ -270,8 +279,8 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldResolveWithSecretTrustAnchorRef() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
         // @formatter:off
         var ingresses = List.of(new IngressesBuilder()
                 .withNewIngressRef()
@@ -306,13 +315,13 @@ class VirtualKafkaClusterReconcilerIT {
         // @formatter:on
         var cluster = specBuilder.endSpec().build();
         var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TLS);
-        operator.create(tlsKeyAndCertSecret(SECRET_NAME));
-        operator.create(secretTrustAnchorRef(SECRET_TRUST_ANCHOR_REF_NAME));
+        clusterUser.create(tlsKeyAndCertSecret(SECRET_NAME));
+        clusterUser.create(secretTrustAnchorRef(SECRET_TRUST_ANCHOR_REF_NAME));
 
-        updateStatusObservedGeneration(operator.create(ingress));
+        updateStatusObservedGeneration(clusterUser.create(ingress));
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster);
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster);
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -322,8 +331,8 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldReportIngressTlsClusterIpBootstrap() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
         // @formatter:off
         var ingresses = List.of(new IngressesBuilder()
                         .withNewIngressRef()
@@ -350,11 +359,11 @@ class VirtualKafkaClusterReconcilerIT {
         // @formatter:on
         var cluster = specBuilder.endSpec().build();
         var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TLS);
-        operator.create(tlsKeyAndCertSecret(SECRET_NAME));
-        updateStatusObservedGeneration(operator.create(ingress));
+        clusterUser.create(tlsKeyAndCertSecret(SECRET_NAME));
+        updateStatusObservedGeneration(clusterUser.create(ingress));
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster);
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster);
 
         // Then
         assertClusterIngressStatusPopulated(clusterBar, ingress, "bar-cluster-ingress-d-bootstrap.%s.svc.cluster.local:9292", Protocol.TLS);
@@ -363,9 +372,9 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldReportIngressLoadBalancerBootstrap() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        operator.create(tlsKeyAndCertSecret(SECRET_NAME));
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        clusterUser.create(tlsKeyAndCertSecret(SECRET_NAME));
         // @formatter:off
         var ingresses = new IngressesBuilder()
                 .withNewIngressRef()
@@ -392,10 +401,10 @@ class VirtualKafkaClusterReconcilerIT {
         // @formatter:on
         var cluster = specBuilder.endSpec().build();
         var ingress = loadBalancerIngress(INGRESS_D, PROXY_A);
-        updateStatusObservedGeneration(operator.create(ingress));
+        updateStatusObservedGeneration(clusterUser.create(ingress));
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster);
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster);
 
         // Then
         assertClusterIngressStatusPopulated(clusterBar, ingress, "bootstrap.kafka:9083", Protocol.TLS);
@@ -404,15 +413,15 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldReportIngressClusterIpBootstrapWhenIngressInitiallyAbsent() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
         var cluster = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
         var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TCP);
 
-        VirtualKafkaCluster clusterBar = operator.create(cluster);
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster);
 
         AWAIT.alias("ClusterStatusBootstrapNotPresent").untilAsserted(() -> {
-            var vkc = operator.resources(VirtualKafkaCluster.class)
+            var vkc = clusterUser.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(clusterBar)).get();
             VirtualKafkaClusterStatus status = vkc.getStatus();
             assertThat(status)
@@ -422,7 +431,7 @@ class VirtualKafkaClusterReconcilerIT {
         });
 
         // When
-        updateStatusObservedGeneration(operator.create(ingress));
+        updateStatusObservedGeneration(clusterUser.create(ingress));
 
         // Then
         assertClusterIngressStatusPopulated(clusterBar, ingress, "bar-cluster-ingress-d-bootstrap.%s.svc.cluster.local:9292", Protocol.TCP);
@@ -459,7 +468,7 @@ class VirtualKafkaClusterReconcilerIT {
 
     private void assertClusterResolvedRefsFalse(VirtualKafkaCluster cr, String expectedReason) {
         AWAIT.alias("ClusterStatusResolvedRefs").untilAsserted(() -> {
-            var vkc = operator.resources(VirtualKafkaCluster.class)
+            var vkc = clusterUser.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(vkc.getStatus()).isNotNull();
             VirtualKafkaClusterStatusAssert
@@ -475,7 +484,7 @@ class VirtualKafkaClusterReconcilerIT {
 
     private void assertAllConditionsTrue(VirtualKafkaCluster cr) {
         AWAIT.alias("ClusterStatusResolvedRefs").untilAsserted(() -> {
-            var vkc = operator.resources(VirtualKafkaCluster.class)
+            var vkc = clusterUser.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(vkc.getStatus()).isNotNull();
             ConditionListAssert conditionListAssert = VirtualKafkaClusterStatusAssert
@@ -494,7 +503,7 @@ class VirtualKafkaClusterReconcilerIT {
     private void assertClusterAcceptedFalse(VirtualKafkaCluster cr,
                                             String expectedReason) {
         AWAIT.alias("ClusterStatusResolvedRefs").untilAsserted(() -> {
-            var vkc = operator.resources(VirtualKafkaCluster.class)
+            var vkc = clusterUser.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(vkc.getStatus()).isNotNull();
             VirtualKafkaClusterStatusAssert
@@ -510,7 +519,7 @@ class VirtualKafkaClusterReconcilerIT {
 
     private void assertClusterIngressStatusPopulated(VirtualKafkaCluster clusterBar, KafkaProxyIngress ingress, String expectedBootstrapServer, Protocol protocol) {
         AWAIT.alias("ClusterIngressStatus").untilAsserted(() -> {
-            var vkc = operator.resources(VirtualKafkaCluster.class)
+            var vkc = clusterUser.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(clusterBar)).get();
             var status = vkc.getStatus();
             assertThat(status)


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Introduces `ClusterUser` — a thin wrapper around a `KubernetesClient` scoped to the test namespace — to give integration tests an explicit, named object representing the actor (a regular Kubernetes user), distinct from the operator (the system under test).

Previously, `LocalKroxyliciousOperatorExtension` exposed `create`, `get`, `replace`, `delete`, and `resources` methods that silently delegated to an internal `TestActor`. This made test code look like the operator itself was creating resources, obscuring the actor/SUT boundary.

**Changes:**
- `ClusterUser`: new class with `create`, `get`, `replace`, `delete`, `resources` — backed by the admin Kubernetes client scoped to the test namespace
- `LocallyRunningOperatorRbacHandler.userClient()`: exposes the lazily-created admin client for constructing a `ClusterUser`
- `LocalKroxyliciousOperatorExtension.clusterUser()`: returns a `ClusterUser` scoped to the test namespace; must be called after `beforeAll`
- All seven `ReconcilerIT` files migrated to obtain a `ClusterUser` via `operator.clusterUser()` and route resource operations through it
- `LocalKroxyliciousOperatorExtension.create/get/replace/delete/resources` removed — they are now dead code
- `patchStatus` remains on the extension: it represents test infrastructure simulating another system updating status subresources, not a user action

`AllReconcilersIT` also updates its parameterised-test lambdas from `Function<LocalKroxyliciousOperatorExtension, T>` to `Function<ClusterUser, T>` since those lambdas create user-side resources (Secrets, ConfigMaps).

### Additional Context

This is a follow-on to `refactor/operator-it-shared-resources` (the base branch). The `ClusterUser` name was chosen deliberately — it communicates a Kubernetes user perspective without overloading the term "user". A future `clusterUser(ClusterRole)` overload could enable RBAC-persona testing (platform team vs. app team) when needed.

### Checklist

- [x] PR raised from a fork of this repository and made from a branch rather than main.
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, trigger the performance test suite.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md