### PR TITLE
refactor(runtime): extract VirtualClusterManager from KafkaProxy

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -151,7 +151,7 @@ public final class KafkaProxy implements AutoCloseable {
     private final NetworkBindingOperationProcessor bindingOperationProcessor = new DefaultNetworkBindingOperationProcessor();
     private final EndpointRegistry endpointRegistry = new EndpointRegistry(bindingOperationProcessor);
     private final PluginFactoryRegistry pfr;
-    private @Nullable VirtualClusterManager vcm;
+    private final VirtualClusterManager vcm;
     private @Nullable MeterRegistries meterRegistries;
     private @Nullable FilterChainFactory filterChainFactory;
     private @Nullable EventGroupConfig managementEventGroup;
@@ -163,6 +163,10 @@ public final class KafkaProxy implements AutoCloseable {
         this.virtualClusterModels = config.virtualClusterModel();
         this.managementConfiguration = config.management();
         this.micrometerConfig = config.getMicrometer();
+        this.vcm = new VirtualClusterManager(virtualClusterModels, (clusterName, cause) -> STARTUP_SHUTDOWN_LOGGER.atInfo()
+                .addKeyValue("virtualCluster", clusterName)
+                .addKeyValue("cause", cause.orElse(null))
+                .log("Virtual cluster stopped"));
     }
 
     @VisibleForTesting
@@ -220,11 +224,6 @@ public final class KafkaProxy implements AutoCloseable {
             STARTUP_SHUTDOWN_LOGGER.atInfo()
                     .log("Kroxylicious is starting");
 
-            this.vcm = new VirtualClusterManager(virtualClusterModels, (clusterName, cause) -> STARTUP_SHUTDOWN_LOGGER.atInfo()
-                    .addKeyValue("virtualCluster", clusterName)
-                    .addKeyValue("cause", cause.orElse(null))
-                    .log("Virtual cluster stopped"));
-
             meterRegistries = new MeterRegistries(pfr, micrometerConfig);
             initVersionInfoMetric();
 
@@ -271,9 +270,7 @@ public final class KafkaProxy implements AutoCloseable {
             STARTUP_SHUTDOWN_LOGGER.atError()
                     .setCause(e)
                     .log("Exception during startup, shutting down");
-            if (vcm != null) {
-                virtualClusterModels.forEach(model -> vcm.initializationFailed(model.getClusterName(), e));
-            }
+            virtualClusterModels.forEach(model -> vcm.initializationFailed(model.getClusterName(), e));
             shutdown();
             throw new LifecycleException("Startup completed exceptionally", e);
         }
@@ -371,9 +368,7 @@ public final class KafkaProxy implements AutoCloseable {
         try {
             STARTUP_SHUTDOWN_LOGGER.atInfo()
                     .log("Shutting down");
-            if (vcm != null) {
-                vcm.transitionAllToDraining();
-            }
+            vcm.transitionAllToDraining();
             endpointRegistry.shutdown().handle((u, t) -> {
                 bindingOperationProcessor.close();
                 var closeFutures = new ArrayList<Future<?>>();
@@ -395,9 +390,7 @@ public final class KafkaProxy implements AutoCloseable {
                 }
                 return null;
             }).toCompletableFuture().join();
-            if (vcm != null) {
-                vcm.transitionAllToStopped();
-            }
+            vcm.transitionAllToStopped();
             if (meterRegistries != null) {
                 meterRegistries.close();
             }
@@ -422,7 +415,7 @@ public final class KafkaProxy implements AutoCloseable {
     @VisibleForTesting
     @Nullable
     VirtualClusterLifecycleManager lifecycleManagerFor(String clusterName) {
-        return vcm != null ? vcm.lifecycleManagerFor(clusterName) : null;
+        return vcm.lifecycleManagerFor(clusterName);
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -163,10 +163,10 @@ public final class KafkaProxy implements AutoCloseable {
         this.virtualClusterModels = config.virtualClusterModel();
         this.managementConfiguration = config.management();
         this.micrometerConfig = config.getMicrometer();
-        this.vcm = new VirtualClusterManager(virtualClusterModels, (clusterName, cause) -> STARTUP_SHUTDOWN_LOGGER.atInfo()
+        this.vcm = new VirtualClusterManager(virtualClusterModels, (clusterName, cause) -> STARTUP_SHUTDOWN_LOGGER.atWarn()
                 .addKeyValue("virtualCluster", clusterName)
                 .addKeyValue("cause", cause.orElse(null))
-                .log("Virtual cluster stopped"));
+                .log("Virtual cluster reached terminal stopped state, proxy shutdown required"));
     }
 
     @VisibleForTesting
@@ -270,6 +270,8 @@ public final class KafkaProxy implements AutoCloseable {
             STARTUP_SHUTDOWN_LOGGER.atError()
                     .setCause(e)
                     .log("Exception during startup, shutting down");
+            // TODO: the onVirtualClusterStopped callback should drive the serve:none policy (triggering proxy shutdown)
+            // rather than relying on the caller to call shutdown() separately. Currently the callback only logs.
             virtualClusterModels.forEach(model -> vcm.initializationFailed(model.getClusterName(), e));
             shutdown();
             throw new LifecycleException("Startup completed exceptionally", e);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -7,7 +7,6 @@ package io.kroxylicious.proxy;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -59,7 +58,7 @@ import io.kroxylicious.proxy.internal.KafkaProxyInitializer;
 import io.kroxylicious.proxy.internal.MeterRegistries;
 import io.kroxylicious.proxy.internal.PortConflictDetector;
 import io.kroxylicious.proxy.internal.VirtualClusterLifecycleManager;
-import io.kroxylicious.proxy.internal.VirtualClusterLifecycleState;
+import io.kroxylicious.proxy.internal.VirtualClusterManager;
 import io.kroxylicious.proxy.internal.admin.ManagementInitializer;
 import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.proxy.internal.net.DefaultNetworkBindingOperationProcessor;
@@ -152,7 +151,7 @@ public final class KafkaProxy implements AutoCloseable {
     private final NetworkBindingOperationProcessor bindingOperationProcessor = new DefaultNetworkBindingOperationProcessor();
     private final EndpointRegistry endpointRegistry = new EndpointRegistry(bindingOperationProcessor);
     private final PluginFactoryRegistry pfr;
-    private final Map<String, VirtualClusterLifecycleManager> lifecycleManagers = new LinkedHashMap<>();
+    private @Nullable VirtualClusterManager vcm;
     private @Nullable MeterRegistries meterRegistries;
     private @Nullable FilterChainFactory filterChainFactory;
     private @Nullable EventGroupConfig managementEventGroup;
@@ -221,9 +220,10 @@ public final class KafkaProxy implements AutoCloseable {
             STARTUP_SHUTDOWN_LOGGER.atInfo()
                     .log("Kroxylicious is starting");
 
-            for (var vcm : virtualClusterModels) {
-                lifecycleManagers.put(vcm.getClusterName(), new VirtualClusterLifecycleManager(vcm.getClusterName()));
-            }
+            this.vcm = new VirtualClusterManager(virtualClusterModels, (clusterName, cause) -> STARTUP_SHUTDOWN_LOGGER.atInfo()
+                    .addKeyValue("virtualCluster", clusterName)
+                    .addKeyValue("cause", cause.orElse(null))
+                    .log("Virtual cluster stopped"));
 
             meterRegistries = new MeterRegistries(pfr, micrometerConfig);
             initVersionInfoMetric();
@@ -261,7 +261,7 @@ public final class KafkaProxy implements AutoCloseable {
                             .toArray(CompletableFuture[]::new))
                     .join();
 
-            lifecycleManagers.values().forEach(VirtualClusterLifecycleManager::initializationSucceeded);
+            virtualClusterModels.forEach(model -> vcm.initializationSucceeded(model.getClusterName()));
 
             STARTUP_SHUTDOWN_LOGGER.atInfo()
                     .log("Kroxylicious is started");
@@ -271,7 +271,9 @@ public final class KafkaProxy implements AutoCloseable {
             STARTUP_SHUTDOWN_LOGGER.atError()
                     .setCause(e)
                     .log("Exception during startup, shutting down");
-            lifecycleManagers.values().forEach(m -> m.initializationFailed(e));
+            if (vcm != null) {
+                virtualClusterModels.forEach(model -> vcm.initializationFailed(model.getClusterName(), e));
+            }
             shutdown();
             throw new LifecycleException("Startup completed exceptionally", e);
         }
@@ -369,7 +371,9 @@ public final class KafkaProxy implements AutoCloseable {
         try {
             STARTUP_SHUTDOWN_LOGGER.atInfo()
                     .log("Shutting down");
-            transitionAllToDraining();
+            if (vcm != null) {
+                vcm.transitionAllToDraining();
+            }
             endpointRegistry.shutdown().handle((u, t) -> {
                 bindingOperationProcessor.close();
                 var closeFutures = new ArrayList<Future<?>>();
@@ -391,7 +395,9 @@ public final class KafkaProxy implements AutoCloseable {
                 }
                 return null;
             }).toCompletableFuture().join();
-            transitionAllToStopped();
+            if (vcm != null) {
+                vcm.transitionAllToStopped();
+            }
             if (meterRegistries != null) {
                 meterRegistries.close();
             }
@@ -416,29 +422,7 @@ public final class KafkaProxy implements AutoCloseable {
     @VisibleForTesting
     @Nullable
     VirtualClusterLifecycleManager lifecycleManagerFor(String clusterName) {
-        return lifecycleManagers.get(clusterName);
-    }
-
-    private void transitionAllToDraining() {
-        lifecycleManagers.values().forEach(m -> {
-            if (m.getState() instanceof VirtualClusterLifecycleState.Serving) {
-                m.startDraining();
-            }
-            else if (m.getState() instanceof VirtualClusterLifecycleState.Failed) {
-                m.stop();
-            }
-            else if (m.getState() instanceof VirtualClusterLifecycleState.Initializing) {
-                m.stop();
-            }
-        });
-    }
-
-    private void transitionAllToStopped() {
-        lifecycleManagers.values().forEach(m -> {
-            if (m.getState() instanceof VirtualClusterLifecycleState.Draining) {
-                m.drainComplete();
-            }
-        });
+        return vcm != null ? vcm.lifecycleManagerFor(clusterName) : null;
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterManager.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterManager.java
@@ -72,6 +72,33 @@ public class VirtualClusterManager {
     }
 
     /**
+     * Signals that the named virtual cluster initialized successfully.
+     * Transitions the cluster from Initializing to Serving.
+     *
+     * @param clusterName the virtual cluster name
+     * @throws IllegalArgumentException if no cluster with that name exists
+     */
+    public void initializationSucceeded(String clusterName) {
+        requireKnownCluster(clusterName).initializationSucceeded();
+    }
+
+    /**
+     * Signals that the named virtual cluster failed to initialize.
+     * Transitions the cluster from Initializing to Failed, then immediately to Stopped
+     * (no recovery path exists today), and fires the {@code onVirtualClusterStopped} callback.
+     *
+     * @param clusterName the virtual cluster name
+     * @param cause the failure cause
+     * @throws IllegalArgumentException if no cluster with that name exists
+     */
+    public void initializationFailed(String clusterName, Throwable cause) {
+        var manager = requireKnownCluster(clusterName);
+        manager.initializationFailed(cause);
+        manager.stop();
+        onVirtualClusterStopped.accept(clusterName, Optional.of(cause));
+    }
+
+    /**
      * Returns the lifecycle manager for the given virtual cluster name.
      * @param clusterName the virtual cluster name
      * @return the lifecycle manager, or null if no cluster with that name exists
@@ -79,5 +106,13 @@ public class VirtualClusterManager {
     @Nullable
     public VirtualClusterLifecycleManager lifecycleManagerFor(String clusterName) {
         return lifecycleManagers.get(clusterName);
+    }
+
+    private VirtualClusterLifecycleManager requireKnownCluster(String clusterName) {
+        var manager = lifecycleManagers.get(clusterName);
+        if (manager == null) {
+            throw new IllegalArgumentException("Unknown cluster: " + clusterName);
+        }
+        return manager;
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterManager.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterManager.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import io.kroxylicious.proxy.model.VirtualClusterModel;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Owns the virtual cluster configuration tree and lifecycle state.
+ * <p>
+ * This is the single source of truth for which virtual clusters exist and their
+ * current lifecycle state. It does not manage networking, endpoint registration,
+ * metrics, or any Netty infrastructure — those remain with {@link io.kroxylicious.proxy.KafkaProxy}.
+ * </p>
+ * <p>
+ * The {@code onVirtualClusterStopped} callback notifies the owner (typically KafkaProxy)
+ * when a virtual cluster reaches the terminal {@link VirtualClusterLifecycleState.Stopped}
+ * state, allowing the owner to apply proxy-level policy (e.g. {@code serve: none}).
+ * During reload, the Draining → Initializing → Serving cycle is managed internally
+ * without involving the callback — reload never reaches Stopped.
+ * </p>
+ */
+public class VirtualClusterManager {
+
+    private final List<VirtualClusterModel> virtualClusterModels;
+    private final Map<String, VirtualClusterLifecycleManager> lifecycleManagers;
+    private final BiConsumer<String, Optional<Throwable>> onVirtualClusterStopped;
+
+    /**
+     * Creates a new VirtualClusterManager for the given set of virtual clusters.
+     *
+     * @param virtualClusterModels the complete set of virtual cluster configurations
+     * @param onVirtualClusterStopped callback invoked with {@code (clusterName, priorFailureCause)}
+     *        whenever a virtual cluster reaches the terminal Stopped state. The cause is empty
+     *        for clean stops (e.g. drain completed during shutdown) and present for failure-driven stops.
+     * @throws NullPointerException if either argument is null
+     * @throws IllegalArgumentException if the list contains duplicate cluster names
+     */
+    public VirtualClusterManager(List<VirtualClusterModel> virtualClusterModels,
+                                 BiConsumer<String, Optional<Throwable>> onVirtualClusterStopped) {
+        Objects.requireNonNull(virtualClusterModels, "virtualClusterModels must not be null");
+        this.onVirtualClusterStopped = Objects.requireNonNull(onVirtualClusterStopped, "onVirtualClusterStopped must not be null");
+        this.virtualClusterModels = List.copyOf(virtualClusterModels);
+        this.lifecycleManagers = new LinkedHashMap<>();
+        for (var vcm : this.virtualClusterModels) {
+            var name = vcm.getClusterName();
+            if (lifecycleManagers.containsKey(name)) {
+                throw new IllegalArgumentException("Duplicate cluster name: " + name);
+            }
+            lifecycleManagers.put(name, new VirtualClusterLifecycleManager(name));
+        }
+    }
+
+    /**
+     * Returns the virtual cluster models this manager was constructed with.
+     * @return unmodifiable list of virtual cluster models
+     */
+    public List<VirtualClusterModel> getVirtualClusterModels() {
+        return virtualClusterModels;
+    }
+
+    /**
+     * Returns the lifecycle manager for the given virtual cluster name.
+     * @param clusterName the virtual cluster name
+     * @return the lifecycle manager, or null if no cluster with that name exists
+     */
+    @Nullable
+    public VirtualClusterLifecycleManager lifecycleManagerFor(String clusterName) {
+        return lifecycleManagers.get(clusterName);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterManager.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/VirtualClusterManager.java
@@ -99,6 +99,44 @@ public class VirtualClusterManager {
     }
 
     /**
+     * Transitions all virtual clusters toward draining/stopped as appropriate for shutdown.
+     * <ul>
+     *   <li>Serving → Draining</li>
+     *   <li>Initializing → Stopped (fires callback with empty cause)</li>
+     *   <li>Failed → Stopped (already handled by initializationFailed)</li>
+     * </ul>
+     */
+    public void transitionAllToDraining() {
+        lifecycleManagers.forEach((name, manager) -> {
+            var state = manager.getState();
+            if (state instanceof VirtualClusterLifecycleState.Serving) {
+                manager.startDraining();
+            }
+            else if (state instanceof VirtualClusterLifecycleState.Initializing) {
+                manager.stop();
+                onVirtualClusterStopped.accept(name, Optional.empty());
+            }
+        });
+    }
+
+    /**
+     * Transitions all draining virtual clusters to stopped, firing the callback for each.
+     *
+     * @return true if all virtual clusters are now in the Stopped state
+     */
+    public boolean transitionAllToStopped() {
+        lifecycleManagers.forEach((name, manager) -> {
+            var state = manager.getState();
+            if (state instanceof VirtualClusterLifecycleState.Draining) {
+                manager.drainComplete();
+                onVirtualClusterStopped.accept(name, Optional.empty());
+            }
+        });
+        return lifecycleManagers.values().stream()
+                .allMatch(m -> m.getState() instanceof VirtualClusterLifecycleState.Stopped);
+    }
+
+    /**
      * Returns the lifecycle manager for the given virtual cluster name.
      * @param clusterName the virtual cluster name
      * @return the lifecycle manager, or null if no cluster with that name exists

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterManagerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterManagerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.model.VirtualClusterModel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class VirtualClusterManagerTest {
+
+    @SuppressWarnings("unchecked")
+    private final BiConsumer<String, Optional<Throwable>> noOpCallback = mock(BiConsumer.class);
+
+    private static VirtualClusterModel mockModel(String name) {
+        var model = mock(VirtualClusterModel.class);
+        when(model.getClusterName()).thenReturn(name);
+        return model;
+    }
+
+    @Test
+    void shouldCreateLifecycleManagerInInitializingState() {
+        // given
+        var vcm = new VirtualClusterManager(List.of(mockModel("cluster-a")), noOpCallback);
+
+        // when
+        var manager = vcm.lifecycleManagerFor("cluster-a");
+
+        // then
+        assertThat(manager).isNotNull()
+                .extracting(VirtualClusterLifecycleManager::getState)
+                .isInstanceOf(VirtualClusterLifecycleState.Initializing.class);
+    }
+
+    @Test
+    void shouldCreateLifecycleManagerForEachModel() {
+        // given
+        var vcm = new VirtualClusterManager(
+                List.of(mockModel("cluster-a"), mockModel("cluster-b")),
+                noOpCallback);
+
+        // when/then
+        assertThat(vcm.lifecycleManagerFor("cluster-a")).isNotNull();
+        assertThat(vcm.lifecycleManagerFor("cluster-b")).isNotNull();
+    }
+
+    @Test
+    void shouldReturnNullForUnknownCluster() {
+        // given
+        var vcm = new VirtualClusterManager(List.of(mockModel("cluster-a")), noOpCallback);
+
+        // when
+        var result = vcm.lifecycleManagerFor("nonexistent");
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void shouldExposeVirtualClusterModels() {
+        // given
+        var modelA = mockModel("cluster-a");
+        var modelB = mockModel("cluster-b");
+        var vcm = new VirtualClusterManager(List.of(modelA, modelB), noOpCallback);
+
+        // when
+        var models = vcm.getVirtualClusterModels();
+
+        // then
+        assertThat(models).containsExactly(modelA, modelB);
+    }
+
+    @Test
+    void shouldRejectNullModels() {
+        assertThatThrownBy(() -> new VirtualClusterManager(null, noOpCallback))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldRejectNullCallback() {
+        List<VirtualClusterModel> virtualClusterModels = List.of(mockModel("cluster-a"));
+        assertThatThrownBy(() -> new VirtualClusterManager(virtualClusterModels, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldRejectDuplicateClusterNames() {
+        List<VirtualClusterModel> virtualClusterModels = List.of(mockModel("cluster-a"), mockModel("cluster-a"));
+        assertThatThrownBy(() -> new VirtualClusterManager(
+                virtualClusterModels,
+                noOpCallback))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cluster-a");
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterManagerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterManagerTest.java
@@ -88,12 +88,14 @@ class VirtualClusterManagerTest {
         assertThat(models).containsExactly(modelA, modelB);
     }
 
+    @SuppressWarnings("DataFlowIssue")
     @Test
     void shouldRejectNullModels() {
         assertThatThrownBy(() -> new VirtualClusterManager(null, noOpCallback))
                 .isInstanceOf(NullPointerException.class);
     }
 
+    @SuppressWarnings("DataFlowIssue")
     @Test
     void shouldRejectNullCallback() {
         List<VirtualClusterModel> virtualClusterModels = List.of(mockModel(CLUSTER_A));
@@ -119,7 +121,8 @@ class VirtualClusterManagerTest {
         vcm.initializationSucceeded(CLUSTER_A);
 
         // then
-        assertThat(vcm.lifecycleManagerFor(CLUSTER_A).getState())
+        assertThat(vcm.lifecycleManagerFor(CLUSTER_A)).isNotNull()
+                .extracting(VirtualClusterLifecycleManager::getState)
                 .isInstanceOf(VirtualClusterLifecycleState.Serving.class);
     }
 
@@ -141,7 +144,8 @@ class VirtualClusterManagerTest {
         vcm.initializationFailed(CLUSTER_A, cause);
 
         // then
-        assertThat(vcm.lifecycleManagerFor(CLUSTER_A).getState())
+        assertThat(vcm.lifecycleManagerFor(CLUSTER_A)).isNotNull()
+                .extracting(VirtualClusterLifecycleManager::getState)
                 .isInstanceOf(VirtualClusterLifecycleState.Stopped.class);
     }
 
@@ -166,7 +170,8 @@ class VirtualClusterManagerTest {
         vcm.initializationFailed(CLUSTER_A, cause);
 
         // then
-        assertThat(vcm.lifecycleManagerFor(CLUSTER_A).getState())
+        assertThat(vcm.lifecycleManagerFor(CLUSTER_A)).isNotNull()
+                .extracting(VirtualClusterLifecycleManager::getState)
                 .isInstanceOfSatisfying(VirtualClusterLifecycleState.Stopped.class,
                         stopped -> assertThat(stopped.priorFailureCause()).isSameAs(cause));
     }
@@ -181,7 +186,109 @@ class VirtualClusterManagerTest {
     @Test
     void shouldThrowForUnknownClusterOnInitializationFailed() {
         // when/then
-        assertThatThrownBy(() -> vcm.initializationFailed("nonexistent", new RuntimeException("boom")))
+        RuntimeException boom = new RuntimeException("boom");
+        assertThatThrownBy(() -> vcm.initializationFailed("nonexistent", boom))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // Bulk shutdown transitions
+
+    @Test
+    void shouldTransitionServingToDrainingOnBulkDrain() {
+        // given
+        vcm.initializationSucceeded(CLUSTER_A);
+
+        // when
+        vcm.transitionAllToDraining();
+
+        // then
+        assertThat(vcm.lifecycleManagerFor(CLUSTER_A)).isNotNull()
+                .extracting(VirtualClusterLifecycleManager::getState)
+                .isInstanceOf(VirtualClusterLifecycleState.Draining.class);
+    }
+
+    @Test
+    void shouldTransitionInitializingToStoppedOnBulkDrain() {
+        // when
+        vcm.transitionAllToDraining();
+
+        // then
+        assertThat(vcm.lifecycleManagerFor(CLUSTER_A)).isNotNull()
+                .extracting(VirtualClusterLifecycleManager::getState)
+                .isInstanceOf(VirtualClusterLifecycleState.Stopped.class);
+    }
+
+    @Test
+    void shouldFireCallbackForInitializingStoppedDuringBulkDrain() {
+        // when
+        vcm.transitionAllToDraining();
+
+        // then
+        verify(noOpCallback).accept(CLUSTER_A, Optional.empty());
+    }
+
+    @Test
+    void shouldNotFireCallbackForServingToDrainingOnBulkDrain() {
+        // given
+        vcm.initializationSucceeded(CLUSTER_A);
+
+        // when
+        vcm.transitionAllToDraining();
+
+        // then
+        verifyNoInteractions(noOpCallback);
+    }
+
+    @Test
+    void shouldTransitionDrainingToStoppedOnBulkStop() {
+        // given
+        vcm.initializationSucceeded(CLUSTER_A);
+        vcm.transitionAllToDraining();
+
+        // when
+        vcm.transitionAllToStopped();
+
+        // then
+        assertThat(vcm.lifecycleManagerFor(CLUSTER_A)).isNotNull()
+                .extracting(VirtualClusterLifecycleManager::getState)
+                .isInstanceOf(VirtualClusterLifecycleState.Stopped.class);
+    }
+
+    @Test
+    void shouldFireCallbackWithEmptyCauseOnBulkStop() {
+        // given
+        vcm.initializationSucceeded(CLUSTER_A);
+        vcm.transitionAllToDraining();
+
+        // when
+        vcm.transitionAllToStopped();
+
+        // then
+        verify(noOpCallback).accept(CLUSTER_A, Optional.empty());
+    }
+
+    @Test
+    void shouldReturnTrueWhenAllClustersStopped() {
+        // given
+        vcm.initializationSucceeded(CLUSTER_A);
+        vcm.transitionAllToDraining();
+
+        // when
+        var allStopped = vcm.transitionAllToStopped();
+
+        // then
+        assertThat(allStopped).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenNotAllClustersStopped() {
+        // given
+        vcm.initializationSucceeded(CLUSTER_A);
+
+        // when
+        var allStopped = vcm.transitionAllToStopped();
+
+        // then
+        assertThat(allStopped).isFalse();
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterManagerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/VirtualClusterManagerTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.proxy.model.VirtualClusterModel;
@@ -17,12 +18,18 @@ import io.kroxylicious.proxy.model.VirtualClusterModel;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class VirtualClusterManagerTest {
 
+    private static final String CLUSTER_A = "cluster-a";
+
     @SuppressWarnings("unchecked")
     private final BiConsumer<String, Optional<Throwable>> noOpCallback = mock(BiConsumer.class);
+
+    private VirtualClusterManager vcm;
 
     private static VirtualClusterModel mockModel(String name) {
         var model = mock(VirtualClusterModel.class);
@@ -30,13 +37,15 @@ class VirtualClusterManagerTest {
         return model;
     }
 
+    @BeforeEach
+    void setUp() {
+        vcm = new VirtualClusterManager(List.of(mockModel(CLUSTER_A)), noOpCallback);
+    }
+
     @Test
     void shouldCreateLifecycleManagerInInitializingState() {
-        // given
-        var vcm = new VirtualClusterManager(List.of(mockModel("cluster-a")), noOpCallback);
-
         // when
-        var manager = vcm.lifecycleManagerFor("cluster-a");
+        var manager = vcm.lifecycleManagerFor(CLUSTER_A);
 
         // then
         assertThat(manager).isNotNull()
@@ -47,20 +56,17 @@ class VirtualClusterManagerTest {
     @Test
     void shouldCreateLifecycleManagerForEachModel() {
         // given
-        var vcm = new VirtualClusterManager(
+        var multiVcm = new VirtualClusterManager(
                 List.of(mockModel("cluster-a"), mockModel("cluster-b")),
                 noOpCallback);
 
         // when/then
-        assertThat(vcm.lifecycleManagerFor("cluster-a")).isNotNull();
-        assertThat(vcm.lifecycleManagerFor("cluster-b")).isNotNull();
+        assertThat(multiVcm.lifecycleManagerFor("cluster-a")).isNotNull();
+        assertThat(multiVcm.lifecycleManagerFor("cluster-b")).isNotNull();
     }
 
     @Test
     void shouldReturnNullForUnknownCluster() {
-        // given
-        var vcm = new VirtualClusterManager(List.of(mockModel("cluster-a")), noOpCallback);
-
         // when
         var result = vcm.lifecycleManagerFor("nonexistent");
 
@@ -73,10 +79,10 @@ class VirtualClusterManagerTest {
         // given
         var modelA = mockModel("cluster-a");
         var modelB = mockModel("cluster-b");
-        var vcm = new VirtualClusterManager(List.of(modelA, modelB), noOpCallback);
+        var multiVcm = new VirtualClusterManager(List.of(modelA, modelB), noOpCallback);
 
         // when
-        var models = vcm.getVirtualClusterModels();
+        var models = multiVcm.getVirtualClusterModels();
 
         // then
         assertThat(models).containsExactly(modelA, modelB);
@@ -90,18 +96,92 @@ class VirtualClusterManagerTest {
 
     @Test
     void shouldRejectNullCallback() {
-        List<VirtualClusterModel> virtualClusterModels = List.of(mockModel("cluster-a"));
+        List<VirtualClusterModel> virtualClusterModels = List.of(mockModel(CLUSTER_A));
         assertThatThrownBy(() -> new VirtualClusterManager(virtualClusterModels, null))
                 .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void shouldRejectDuplicateClusterNames() {
-        List<VirtualClusterModel> virtualClusterModels = List.of(mockModel("cluster-a"), mockModel("cluster-a"));
+        List<VirtualClusterModel> virtualClusterModels = List.of(mockModel(CLUSTER_A), mockModel(CLUSTER_A));
         assertThatThrownBy(() -> new VirtualClusterManager(
                 virtualClusterModels,
                 noOpCallback))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("cluster-a");
+                .hasMessageContaining(CLUSTER_A);
+    }
+
+    // Per-VC lifecycle transitions
+
+    @Test
+    void shouldTransitionNamedClusterToServing() {
+        // when
+        vcm.initializationSucceeded(CLUSTER_A);
+
+        // then
+        assertThat(vcm.lifecycleManagerFor(CLUSTER_A).getState())
+                .isInstanceOf(VirtualClusterLifecycleState.Serving.class);
+    }
+
+    @Test
+    void shouldNotFireCallbackOnInitializationSuccess() {
+        // when
+        vcm.initializationSucceeded(CLUSTER_A);
+
+        // then
+        verifyNoInteractions(noOpCallback);
+    }
+
+    @Test
+    void shouldTransitionToStoppedOnInitializationFailure() {
+        // given
+        var cause = new RuntimeException("filter init failed");
+
+        // when
+        vcm.initializationFailed(CLUSTER_A, cause);
+
+        // then
+        assertThat(vcm.lifecycleManagerFor(CLUSTER_A).getState())
+                .isInstanceOf(VirtualClusterLifecycleState.Stopped.class);
+    }
+
+    @Test
+    void shouldFireCallbackOnInitializationFailure() {
+        // given
+        var cause = new RuntimeException("filter init failed");
+
+        // when
+        vcm.initializationFailed(CLUSTER_A, cause);
+
+        // then
+        verify(noOpCallback).accept(CLUSTER_A, Optional.of(cause));
+    }
+
+    @Test
+    void shouldRetainFailureCauseInStoppedState() {
+        // given
+        var cause = new RuntimeException("filter init failed");
+
+        // when
+        vcm.initializationFailed(CLUSTER_A, cause);
+
+        // then
+        assertThat(vcm.lifecycleManagerFor(CLUSTER_A).getState())
+                .isInstanceOfSatisfying(VirtualClusterLifecycleState.Stopped.class,
+                        stopped -> assertThat(stopped.priorFailureCause()).isSameAs(cause));
+    }
+
+    @Test
+    void shouldThrowForUnknownClusterOnInitializationSucceeded() {
+        // when/then
+        assertThatThrownBy(() -> vcm.initializationSucceeded("nonexistent"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldThrowForUnknownClusterOnInitializationFailed() {
+        // when/then
+        assertThatThrownBy(() -> vcm.initializationFailed("nonexistent", new RuntimeException("boom")))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Extracts `VirtualClusterManager` (VCM) from `KafkaProxy` to own the virtual cluster configuration tree and lifecycle state. VCM is the single source of truth for which virtual clusters exist and their current lifecycle state. It does not manage networking, endpoint registration, or metrics — those remain with `KafkaProxy`.

Key changes:
- New `VirtualClusterManager` with per-VC lifecycle transitions (`initializationSucceeded`, `initializationFailed`) and bulk shutdown transitions (`transitionAllToDraining`, `transitionAllToStopped`)
- `onVirtualClusterStopped` callback notifies KafkaProxy when a VC reaches terminal Stopped state
- `initializationFailed` chains Failed → Stopped immediately (no recovery path today) and fires the callback
- `transitionAllToStopped` returns `boolean` indicating whether all clusters are now stopped
- KafkaProxy delegates lifecycle management to VCM, removing its private transition methods

### Additional Context

Provides a clean foundation for hot reload (#3369) by separating lifecycle ownership from the Netty process container. After this change, KafkaProxy owns event loops, bootstraps, management endpoint, and metrics. VCM owns "what the proxy serves" (models + lifecycle state). The reload path (Serving → Draining → Initializing → Serving) stays entirely within VCM without involving the callback — reload never reaches Stopped.

Builds on #3640 (virtual cluster lifecycle state tracking).

### Checklist

- [x] PR raised from a fork of this repository and made from a branch rather than main.
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).