### PR TITLE
fix(benchmarks): make kafka.version optional in Helm template

### DIFF
--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/kafka-strimzi.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/kafka-strimzi.yaml
@@ -12,7 +12,9 @@ metadata:
     app: kafka
 spec:
   kafka:
+    {{- if .Values.kafka.version }}
     version: {{ .Values.kafka.version }}
+    {{- end }}
     listeners:
       - name: plain
         port: 9092


### PR DESCRIPTION
## Summary

Fixes the kafka.version template rendering to be truly optional, allowing Strimzi to provide a default when the value is not set.

## Problem

Commit ed1d43e20 removed `kafka.version` from `values.yaml` to allow Strimzi to default the version. However, the template still unconditionally rendered:

```yaml
version: {{ .Values.kafka.version }}
```

When `.Values.kafka.version` is undefined, this produces `version: ` (empty/null), which Strimzi 1.0.0 rejects with:

```
spec.kafka.version: Invalid value: "null": spec.kafka.version in body must be of type string: "null"
```

## Solution

Wrap the version field in a Helm conditional:

```yaml
{{- if .Values.kafka.version }}
version: {{ .Values.kafka.version }}
{{- end }}
```

- When `kafka.version` is **not set**: field is omitted entirely, Strimzi uses its default
- When `kafka.version` **is set**: field is rendered normally

## Testing

Verified with `helm template`:

**Without kafka.version:**
```bash
helm template benchmark helm/kroxylicious-benchmark | grep -A 5 "spec:"
```
Result: `version:` field is absent ✓

**With kafka.version:**
```bash
helm template benchmark helm/kroxylicious-benchmark --set kafka.version="4.2.0" | grep -A 5 "spec:"
```
Result: `version: 4.2.0` is rendered ✓

## Notes

This issue was discovered when testing PR #3887 on a cluster with Strimzi 1.0.0, which has stricter validation than Strimzi 0.51.0 (the version this PR targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)