### PR TITLE
refactor: lock down transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format `<github issue/pr number>: <short description>`.
 ### Changes, deprecations and removals
 
 * [#3913](https://github.com/kroxylicious/kroxylicious/pull/3913): The operator now sets a `DeprecationWarning` status condition on `KafkaProxy` resources that have no `spec` field, complementing the existing log warning. Users should add an empty `spec: {}` to any `KafkaProxy` resource that lacks one. Support for spec-less `KafkaProxy` resources will be removed in a future release.
+* [#3828](https://github.com/kroxylicious/kroxylicious/pull/3828): remove `KafkaProxy.block()` — use `startup().join()` instead. KafkaProxy is considered internal API hence we are skipping the deprecation cycle
 
 ## 0.21.0
 

--- a/kroxylicious-app/src/main/java/io/kroxylicious/app/Kroxylicious.java
+++ b/kroxylicious-app/src/main/java/io/kroxylicious/app/Kroxylicious.java
@@ -76,7 +76,6 @@ public class Kroxylicious implements Callable<Integer> {
             Features features = getFeatures();
             printBannerAndVersions(features);
             try (KafkaProxy kafkaProxy = proxyBuilder.build(configParser, config, features)) {
-                kafkaProxy.startup();
                 Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                     try {
                         kafkaProxy.close();
@@ -92,7 +91,7 @@ public class Kroxylicious implements Callable<Integer> {
                         LogManager.shutdown();
                     }
                 }, "proxy-shutdown-hook"));
-                kafkaProxy.block();
+                kafkaProxy.startup().join();
             }
         }
         catch (Exception e) {

--- a/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousTest.java
+++ b/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousTest.java
@@ -12,6 +12,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
@@ -32,7 +33,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -90,28 +90,27 @@ class KroxyliciousTest {
     @Test
     void testKroxyliciousStartsAndThenTerminates(@TempDir Path dir) throws Exception {
         Path file = copyClasspathResourceToTempFileInDir("proxy-config.yaml", dir);
-        when(mockProxy.startup()).thenReturn(mockProxy);
-        doNothing().when(mockProxy).block();
+        when(mockProxy.startup()).thenReturn(CompletableFuture.completedFuture(null));
         assertEquals(0, cmd.execute("-c", file.toString()));
     }
 
     @Test
     void testDefaultFeatures(@TempDir Path dir) throws Exception {
         Path file = copyClasspathResourceToTempFileInDir("proxy-config.yaml", dir);
-        when(mockProxy.startup()).thenReturn(mockProxy);
-        doNothing().when(mockProxy).block();
+        when(mockProxy.startup()).thenReturn(CompletableFuture.completedFuture(null));
         assertEquals(0, cmd.execute("-c", file.toString()));
         assertThat(features).hasValue(Features.defaultFeatures());
     }
 
     @Test
-    void testKroxyliciousExceptionOnBlock(@TempDir Path dir) throws Exception {
+    void testKroxyliciousExceptionDuringRun(@TempDir Path dir) throws Exception {
         Path file = copyClasspathResourceToTempFileInDir("proxy-config.yaml", dir);
-        when(mockProxy.startup()).thenReturn(mockProxy);
-        Mockito.doThrow(new RuntimeException("exception on block")).when(mockProxy).block();
+        var failedFuture = new CompletableFuture<Void>();
+        failedFuture.completeExceptionally(new RuntimeException("exception during run"));
+        when(mockProxy.startup()).thenReturn(failedFuture);
         int execute = cmd.execute("-c", file.toString());
         assertEquals(1, execute);
-        assertThat(stdErr()).contains("exception on block");
+        assertThat(stdErr()).contains("exception during run");
     }
 
     @Test

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -216,10 +216,9 @@ public final class KafkaProxy implements AutoCloseable {
 
     /**
      * Starts this proxy.
-     * @return This proxy.
+     * @return a future that completes when the proxy stops (normally or exceptionally).
      */
-    @SuppressWarnings("java:S5738")
-    public KafkaProxy startup() {
+    public CompletableFuture<Void> startup() {
         if (running.getAndSet(true)) {
             throw new IllegalStateException("This proxy is already running");
         }
@@ -287,7 +286,7 @@ public final class KafkaProxy implements AutoCloseable {
 
             STARTUP_SHUTDOWN_LOGGER.atInfo()
                     .log("Kroxylicious is started");
-            return this;
+            return shutdown;
         }
         catch (RuntimeException e) {
             STARTUP_SHUTDOWN_LOGGER.atError()

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -403,15 +403,6 @@ public final class KafkaProxy implements AutoCloseable {
     }
 
     /**
-     * Blocks while this proxy is running.
-     * @deprecated Use {@code startup().join()} instead.
-     */
-    @Deprecated(since = "0.21.0")
-    public void block() {
-        shutdown.join();
-    }
-
-    /**
      * Shuts down a running proxy. Idempotent: safe to call from any thread, including JVM shutdown hooks,
      * and safe to call before {@link #startup()} or after already stopped.
      */

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -15,7 +15,7 @@ import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -143,12 +143,26 @@ public final class KafkaProxy implements AutoCloseable {
         }
     }
 
+    private enum LifecycleState {
+        NEW,
+        STARTING,
+        STARTED,
+        STOPPING,
+        STOPPED
+    }
+
     private final Configuration config;
     private final @Nullable ManagementConfiguration managementConfiguration;
     private final List<MicrometerDefinition> micrometerConfig;
     private final List<VirtualClusterModel> virtualClusterModels;
-    private final AtomicBoolean running = new AtomicBoolean();
-    private final CompletableFuture<Void> shutdown = new CompletableFuture<>();
+    private final AtomicReference<LifecycleState> state = new AtomicReference<>(LifecycleState.NEW);
+    private final CompletableFuture<Void> shutdown = new CompletableFuture<>() {
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            KafkaProxy.this.shutdown();
+            return false;
+        }
+    };
     private final NetworkBindingOperationProcessor bindingOperationProcessor = new DefaultNetworkBindingOperationProcessor();
     private final EndpointRegistry endpointRegistry = new EndpointRegistry(bindingOperationProcessor);
     private final PluginFactoryRegistry pfr;
@@ -219,8 +233,12 @@ public final class KafkaProxy implements AutoCloseable {
      * @return a future that completes when the proxy stops (normally or exceptionally).
      */
     public CompletableFuture<Void> startup() {
-        if (running.getAndSet(true)) {
-            throw new IllegalStateException("This proxy is already running");
+        if (!state.compareAndSet(LifecycleState.NEW, LifecycleState.STARTING)) {
+            LifecycleState current = state.get();
+            if (current == LifecycleState.STOPPING || current == LifecycleState.STOPPED) {
+                throw new IllegalStateException("KafkaProxy is not restartable");
+            }
+            return shutdown; // STARTING or STARTED — idempotent
         }
         try {
             if (!TESTED_JRE_VERSIONS.contains(JRE_FEATURE_VERSION)) {
@@ -286,6 +304,7 @@ public final class KafkaProxy implements AutoCloseable {
 
             STARTUP_SHUTDOWN_LOGGER.atInfo()
                     .log("Kroxylicious is started");
+            state.set(LifecycleState.STARTED);
             return shutdown;
         }
         catch (RuntimeException e) {
@@ -296,9 +315,12 @@ public final class KafkaProxy implements AutoCloseable {
             // rather than relying on the caller to call shutdown() separately. Currently the callback only logs.
             // All VCs are failed with the same exception because startup is all-or-nothing:
             // initializationSucceeded is only called after all VCs register successfully (line 263).
+            var wrapped = new LifecycleException("Startup completed exceptionally", e);
             virtualClusterModels.forEach(model -> virtualClusterRegistry.initializationFailed(model.getClusterName(), e));
-            shutdown();
-            throw new LifecycleException("Startup completed exceptionally", e);
+            state.set(LifecycleState.STOPPING);
+            shutdown.completeExceptionally(wrapped); // claim the future before doShutdown() can complete it normally
+            doShutdown();
+            throw wrapped;
         }
     }
 
@@ -375,27 +397,26 @@ public final class KafkaProxy implements AutoCloseable {
 
     /**
      * Blocks while this proxy is running.
-     * This should only be called after a successful call to {@link #startup()}.
+     * @deprecated Use {@code startup().join()} instead.
      */
+    @Deprecated(since = "0.11.0")
     public void block() {
-        if (!running.get()) {
-            throw new IllegalStateException("This proxy is not running");
-        }
         shutdown.join();
     }
 
     /**
-     * Shuts down a running proxy. The sequence is:
-     * <ol>
-     *   <li>Unbind ports — prevents new connections from arriving</li>
-     *   <li>Drain existing connections gracefully via {@code shutdownAllClusters()}</li>
-     *   <li>Shut down Netty event groups — force-closes any connections that did not drain in time</li>
-     * </ol>
+     * Shuts down a running proxy. Idempotent: safe to call from any thread, including JVM shutdown hooks,
+     * and safe to call before {@link #startup()} or after already stopped.
      */
     public void shutdown() {
-        if (!running.getAndSet(false)) {
-            throw new IllegalStateException("This proxy is not running");
+        if (!state.compareAndSet(LifecycleState.STARTED, LifecycleState.STOPPING)) {
+            return; // no-op in all other states
         }
+        doShutdown();
+    }
+
+    private void doShutdown() {
+        Exception shutdownFailure = null;
         try {
             STARTUP_SHUTDOWN_LOGGER.atInfo()
                     .log("Shutting down");
@@ -408,8 +429,8 @@ public final class KafkaProxy implements AutoCloseable {
                 if (t != null) {
                     STARTUP_SHUTDOWN_LOGGER.atWarn()
                             .setCause(t)
-                            .log("Shutdown future completed exceptionally");
-                    throw new LifecycleException("Shutdown future completed exceptionally", t);
+                            .log("Shutdown completed exceptionally");
+                    throw new LifecycleException("Shutdown completed exceptionally", t);
                 }
                 return null;
             }).toCompletableFuture().join();
@@ -440,14 +461,23 @@ public final class KafkaProxy implements AutoCloseable {
                 meterRegistries.close();
             }
         }
+        catch (Exception e) {
+            shutdownFailure = e;
+        }
         finally {
             // Close virtual cluster models to release TLS credential supplier resources
             virtualClusterModels.forEach(VirtualClusterModel::close);
+            state.set(LifecycleState.STOPPED);
             managementEventGroup = null;
             proxyEventGroup = null;
             meterRegistries = null;
             filterChainFactory = null;
-            shutdown.complete(null);
+            if (shutdownFailure != null) {
+                shutdown.completeExceptionally(shutdownFailure);
+            }
+            else {
+                shutdown.complete(null);
+            }
             LOGGER.atInfo()
                     .log("Shut down completed");
         }
@@ -479,10 +509,8 @@ public final class KafkaProxy implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
-        if (running.get()) {
-            shutdown();
-        }
+    public void close() {
+        shutdown();
     }
 
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -16,7 +16,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -240,13 +242,15 @@ public final class KafkaProxy implements AutoCloseable {
     public CompletableFuture<Void> startup() {
         // The CAS is the primary guard against concurrent startup; the STOPPING/STOPPED
         // check is belt-and-braces since the real concurrency guard is in shutdown().
-        if (!state.compareAndSet(LifecycleState.NEW, LifecycleState.STARTING)) {
-            LifecycleState current = state.get();
+        return transitionTo(LifecycleState.STARTING, this::doStartup, current -> {
             if (current == LifecycleState.STOPPING || current == LifecycleState.STOPPED) {
                 throw new IllegalStateException("KafkaProxy is not restartable");
             }
             return shutdown; // STARTING or STARTED — idempotent
-        }
+        });
+    }
+
+    private CompletableFuture<Void> doStartup() {
         try {
             if (!TESTED_JRE_VERSIONS.contains(JRE_FEATURE_VERSION)) {
                 String versionStatus = "untested";
@@ -311,8 +315,9 @@ public final class KafkaProxy implements AutoCloseable {
 
             STARTUP_SHUTDOWN_LOGGER.atInfo()
                     .log("Kroxylicious is started");
-            state.set(LifecycleState.STARTED);
-            return shutdown;
+            return transitionTo(LifecycleState.STARTED, () -> shutdown, lifecycleState -> {
+                throw new LifecycleException("failed to start Kroxylicious lifecycle state");
+            });
         }
         catch (RuntimeException e) {
             STARTUP_SHUTDOWN_LOGGER.atError()
@@ -324,11 +329,54 @@ public final class KafkaProxy implements AutoCloseable {
             // initializationSucceeded is only called after all VCs register successfully (line 263).
             var wrapped = new LifecycleException("Startup completed exceptionally", e);
             virtualClusterModels.forEach(model -> virtualClusterRegistry.initializationFailed(model.getClusterName(), e));
-            state.set(LifecycleState.STOPPING);
             shutdown.completeExceptionally(wrapped); // claim the future before doShutdown() can complete it normally
-            doShutdown();
+            transitionTo(LifecycleState.STOPPING, this::doShutdown, lifecycleState -> {
+            });
             throw wrapped;
         }
+    }
+
+    private void transitionTo(LifecycleState targetState,
+                              Runnable onTransition,
+                              Consumer<LifecycleState> onNoTransition) {
+        this.transitionTo(targetState, () -> {
+            onTransition.run();
+            return null;
+        }, lifecycleState -> {
+            onNoTransition.accept(lifecycleState);
+            return null;
+        });
+    }
+
+    /**
+     *
+     * @param targetState target state
+     * @param onTransition executed if this call transitions to the targetState
+     * @return the last observed state, could be the targetState if successfully transitioned, else last
+     */
+    private <T> T transitionTo(LifecycleState targetState,
+                               Supplier<T> onTransition,
+                               Function<LifecycleState, T> onNoTransition) {
+        boolean transitioned = false;
+        while (!transitioned) {
+            LifecycleState currentState = state.get();
+            if (currentState == targetState) {
+                // something else has already transitioned to this state
+                return onNoTransition.apply(currentState);
+            }
+            boolean validTransition = switch (currentState) {
+                case NEW -> targetState == LifecycleState.STARTING || targetState == LifecycleState.STOPPING;
+                case STARTING -> targetState == LifecycleState.STARTED || targetState == LifecycleState.STOPPING;
+                case STARTED -> targetState == LifecycleState.STOPPING;
+                case STOPPING -> targetState == LifecycleState.STOPPED;
+                case STOPPED -> false;
+            };
+            if (!validTransition) {
+                return onNoTransition.apply(currentState);
+            }
+            transitioned = state.compareAndSet(currentState, targetState);
+        }
+        return onTransition.get();
     }
 
     private static Optional<NettySettings> getNettySettings(Configuration configuration, Function<NetworkDefinition, NettySettings> settingsSupplier) {
@@ -407,10 +455,8 @@ public final class KafkaProxy implements AutoCloseable {
      * and safe to call before {@link #startup()} or after already stopped.
      */
     public void shutdown() {
-        if (!state.compareAndSet(LifecycleState.STARTED, LifecycleState.STOPPING)) {
-            return; // no-op in all other states
-        }
-        doShutdown();
+        transitionTo(LifecycleState.STOPPING, this::doShutdown, lifecycleState -> {
+        });
     }
 
     private void doShutdown() {
@@ -465,7 +511,10 @@ public final class KafkaProxy implements AutoCloseable {
         finally {
             // Close virtual cluster models to release TLS credential supplier resources
             virtualClusterModels.forEach(VirtualClusterModel::close);
-            state.set(LifecycleState.STOPPED);
+            transitionTo(LifecycleState.STOPPED, () -> {
+            }, lifecycleState -> {
+                throw new LifecycleException("failed to transition to stopped from state: " + lifecycleState);
+            });
             managementEventGroup = null;
             proxyEventGroup = null;
             meterRegistries = null;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -238,6 +238,8 @@ public final class KafkaProxy implements AutoCloseable {
      * @return a future that completes when the proxy stops (normally or exceptionally).
      */
     public CompletableFuture<Void> startup() {
+        // The CAS is the primary guard against concurrent startup; the STOPPING/STOPPED
+        // check is belt-and-braces since the real concurrency guard is in shutdown().
         if (!state.compareAndSet(LifecycleState.NEW, LifecycleState.STARTING)) {
             LifecycleState current = state.get();
             if (current == LifecycleState.STOPPING || current == LifecycleState.STOPPED) {
@@ -404,7 +406,7 @@ public final class KafkaProxy implements AutoCloseable {
      * Blocks while this proxy is running.
      * @deprecated Use {@code startup().join()} instead.
      */
-    @Deprecated(since = "0.11.0")
+    @Deprecated(since = "0.21.0")
     public void block() {
         shutdown.join();
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -228,6 +228,11 @@ public final class KafkaProxy implements AutoCloseable {
         return proxyEventGroup;
     }
 
+    @VisibleForTesting
+    CompletableFuture<Void> shutdownFuture() {
+        return shutdown;
+    }
+
     /**
      * Starts this proxy.
      * @return a future that completes when the proxy stops (normally or exceptionally).

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/LifecycleException.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/LifecycleException.java
@@ -14,4 +14,8 @@ public class LifecycleException extends RuntimeException {
     public LifecycleException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    public LifecycleException(String message) {
+        super(message);
+    }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
@@ -16,6 +16,7 @@ import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class KafkaProxyLifecycleTest {
@@ -111,6 +112,63 @@ class KafkaProxyLifecycleTest {
         // then
         assertThat(manager).isNotNull();
         assertThat(manager.state()).isInstanceOf(Stopped.class);
+    }
+
+    @Test
+    void shutdownBeforeStartupIsNoOp() {
+        var config = """
+                   virtualClusters:
+                     - name: demo1
+                       targetCluster:
+                         bootstrapServers: kafka.example:1234
+                       gateways:
+                       - name: default
+                         portIdentifiesNode:
+                           bootstrapAddress: localhost:9192
+                """;
+
+        var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures());
+        assertThatCode(proxy::shutdown).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shutdownTwiceIsNoOp() {
+        var config = """
+                   virtualClusters:
+                     - name: demo1
+                       targetCluster:
+                         bootstrapServers: kafka.example:1234
+                       gateways:
+                       - name: default
+                         portIdentifiesNode:
+                           bootstrapAddress: localhost:9192
+                """;
+
+        var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures());
+        proxy.startup();
+        proxy.shutdown();
+        assertThatCode(proxy::shutdown).doesNotThrowAnyException();
+    }
+
+    @Test
+    void startupAfterStopThrowsIllegalState() {
+        var config = """
+                   virtualClusters:
+                     - name: demo1
+                       targetCluster:
+                         bootstrapServers: kafka.example:1234
+                       gateways:
+                       - name: default
+                         portIdentifiesNode:
+                           bootstrapAddress: localhost:9192
+                """;
+
+        var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures());
+        proxy.startup();
+        proxy.shutdown();
+        assertThatThrownBy(proxy::startup)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("KafkaProxy is not restartable");
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -112,6 +114,50 @@ class KafkaProxyLifecycleTest {
         // then
         assertThat(manager).isNotNull();
         assertThat(manager.state()).isInstanceOf(Stopped.class);
+    }
+
+    @Test
+    void startupReturnsFutureThatCompletesOnShutdown() {
+        var config = """
+                   virtualClusters:
+                     - name: demo1
+                       targetCluster:
+                         bootstrapServers: kafka.example:1234
+                       gateways:
+                       - name: default
+                         portIdentifiesNode:
+                           bootstrapAddress: localhost:9192
+                """;
+
+        var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures());
+        CompletableFuture<Void> future = proxy.startup();
+        assertThat(future).isNotNull().isNotDone();
+        proxy.shutdown();
+        assertThat(future).isCompletedWithValue(null);
+    }
+
+    @Test
+    void startupTwiceReturnsSameFutureInstance() {
+        var config = """
+                   virtualClusters:
+                     - name: demo1
+                       targetCluster:
+                         bootstrapServers: kafka.example:1234
+                       gateways:
+                       - name: default
+                         portIdentifiesNode:
+                           bootstrapAddress: localhost:9192
+                """;
+
+        var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures());
+        try {
+            CompletableFuture<Void> first = proxy.startup();
+            CompletableFuture<Void> second = proxy.startup();
+            assertThat(second).isSameAs(first);
+        }
+        finally {
+            proxy.shutdown();
+        }
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.proxy;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.internal.VirtualClusterLifecycleState.Serving;
 import io.kroxylicious.proxy.internal.VirtualClusterLifecycleState.Stopped;
+import io.kroxylicious.proxy.internal.VirtualClusterRegistry;
 import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
@@ -215,6 +217,149 @@ class KafkaProxyLifecycleTest {
         assertThatThrownBy(proxy::startup)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("KafkaProxy is not restartable");
+    }
+
+    @Test
+    void cancelOnFutureTriggersGracefulShutdown() {
+        var config = """
+                   virtualClusters:
+                     - name: demo1
+                       targetCluster:
+                         bootstrapServers: kafka.example:1234
+                       gateways:
+                       - name: default
+                         portIdentifiesNode:
+                           bootstrapAddress: localhost:9192
+                """;
+
+        var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures());
+        CompletableFuture<Void> future = proxy.startup();
+
+        boolean cancelled = future.cancel(true);
+
+        assertThat(cancelled).isFalse();
+        assertThat(future).isCompletedWithValue(null);
+    }
+
+    @Test
+    void closeIsIdempotent() {
+        var config = """
+                   virtualClusters:
+                     - name: demo1
+                       targetCluster:
+                         bootstrapServers: kafka.example:1234
+                       gateways:
+                       - name: default
+                         portIdentifiesNode:
+                           bootstrapAddress: localhost:9192
+                """;
+
+        var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures());
+        proxy.startup();
+        assertThatCode(proxy::close).doesNotThrowAnyException();
+        assertThatCode(proxy::close).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shutdownFromDifferentThread() {
+        var config = """
+                   virtualClusters:
+                     - name: demo1
+                       targetCluster:
+                         bootstrapServers: kafka.example:1234
+                       gateways:
+                       - name: default
+                         portIdentifiesNode:
+                           bootstrapAddress: localhost:9192
+                """;
+
+        var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures());
+        CompletableFuture<Void> future = proxy.startup();
+
+        CompletableFuture.runAsync(proxy::shutdown).join();
+
+        assertThat(future).isCompletedWithValue(null);
+    }
+
+    @Test
+    void futureCompletesExceptionallyWhenStartupFails() {
+        var config = """
+                   virtualClusters:
+                     - name: demo1
+                       targetCluster:
+                         bootstrapServers: kafka.example:1234
+                       gateways:
+                       - name: default
+                         portIdentifiesNode:
+                           bootstrapAddress: localhost:9192
+                   filterDefinitions:
+                   - name: filter1
+                     type: RequiresConfigFactory
+                   defaultFilters:
+                   - filter1
+                """;
+
+        var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures());
+        assertThatThrownBy(proxy::startup).isInstanceOf(LifecycleException.class);
+
+        assertThat(proxy.shutdownFuture())
+                .isCompletedExceptionally()
+                .failsWithin(java.time.Duration.ZERO)
+                .withThrowableOfType(java.util.concurrent.ExecutionException.class)
+                .withCauseInstanceOf(LifecycleException.class);
+    }
+
+    @Test
+    void startupWhileStoppingThrows() throws InterruptedException {
+        var config = """
+                   virtualClusters:
+                     - name: demo1
+                       targetCluster:
+                         bootstrapServers: kafka.example:1234
+                       gateways:
+                       - name: default
+                         portIdentifiesNode:
+                           bootstrapAddress: localhost:9192
+                """;
+
+        var configuration = configParser.parseConfiguration(config);
+        var models = configuration.virtualClusterModel(configParser);
+
+        var shutdownStarted = new CountDownLatch(1);
+        var allowShutdown = new CountDownLatch(1);
+
+        var blockingRegistry = new VirtualClusterRegistry(models, (name, cause) -> {
+        }) {
+            @Override
+            public void shutdownAllClusters() {
+                shutdownStarted.countDown();
+                try {
+                    allowShutdown.await();
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                super.shutdownAllClusters();
+            }
+        };
+
+        var proxy = new KafkaProxy(configParser, configuration, Features.defaultFeatures(), blockingRegistry);
+        proxy.startup();
+
+        var shutdownThread = new Thread(proxy::shutdown);
+        shutdownThread.start();
+        shutdownStarted.await();
+
+        try {
+            // proxy is in STOPPING state while shutdownAllClusters() is blocked
+            assertThatThrownBy(proxy::startup)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("KafkaProxy is not restartable");
+        }
+        finally {
+            allowShutdown.countDown();
+            shutdownThread.join(5_000);
+        }
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyLifecycleTest.java
@@ -363,6 +363,39 @@ class KafkaProxyLifecycleTest {
     }
 
     @Test
+    void futureCompletesExceptionallyWhenShutdownFails() {
+        var config = """
+                   virtualClusters:
+                     - name: demo1
+                       targetCluster:
+                         bootstrapServers: kafka.example:1234
+                       gateways:
+                       - name: default
+                         portIdentifiesNode:
+                           bootstrapAddress: localhost:9192
+                   filterDefinitions:
+                   - name: filter1
+                     type: FlakyFactory
+                     config:
+                       closeExceptionMsg: "simulated close failure"
+                   defaultFilters:
+                   - filter1
+                """;
+
+        var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures());
+        CompletableFuture<Void> future = proxy.startup();
+
+        proxy.shutdown();
+
+        assertThat(future)
+                .isCompletedExceptionally()
+                .failsWithin(java.time.Duration.ZERO)
+                .withThrowableOfType(java.util.concurrent.ExecutionException.class)
+                .withCauseInstanceOf(RuntimeException.class)
+                .withMessageContaining("simulated close failure");
+    }
+
+    @Test
     void shouldTransitionToStoppedOnStartupFailure() throws Exception {
         // given
         var config = """

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -12,7 +12,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.stream.Stream;
 
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
@@ -367,11 +366,11 @@ class KafkaProxyTest {
     }
 
     @Test
-    void shouldNotAllowMultipleConcurrentStarts() throws Exception {
+    void startupTwiceReturnsSameFuture() throws Exception {
         try (var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(MINIMUM_VIABLE_CONFIG_YAML), Features.defaultFeatures())) {
-            proxy.startup();
-
-            assertThatThrownBy(proxy::startup).isInstanceOf(IllegalStateException.class).hasMessage("This proxy is already running");
+            var first = proxy.startup();
+            var second = proxy.startup();
+            assertThat(second).isSameAs(first);
         }
     }
 
@@ -398,11 +397,10 @@ class KafkaProxyTest {
                            bootstrapAddress: localhost:9192
                 """), Features.defaultFeatures())) {
             // When
-            KafkaProxy kafkaProxy = proxy.startup();
+            proxy.startup();
 
             // Then
-            assertThat(kafkaProxy).isInstanceOf(KafkaProxy.class)
-                    .extracting("managementEventGroup", InstanceOfAssertFactories.type(KafkaProxy.EventGroupConfig.class))
+            assertThat(proxy.managementEventGroup())
                     .satisfies(eventGroupConfig -> assertThat(eventGroupConfig.clazz()).isAssignableFrom(IoUringServerSocketChannel.class));
 
         }
@@ -423,11 +421,10 @@ class KafkaProxyTest {
                            bootstrapAddress: localhost:9192
                 """), Features.defaultFeatures())) {
             // When
-            KafkaProxy kafkaProxy = proxy.startup();
+            proxy.startup();
 
             // Then
-            assertThat(kafkaProxy).isInstanceOf(KafkaProxy.class)
-                    .extracting("managementEventGroup", InstanceOfAssertFactories.type(KafkaProxy.EventGroupConfig.class))
+            assertThat(proxy.managementEventGroup())
                     .satisfiesAnyOf(eventGroupConfig -> assertThat(eventGroupConfig.clazz()).isAssignableFrom(EpollServerSocketChannel.class),
                             eventGroupConfig -> assertThat(eventGroupConfig.clazz()).isAssignableFrom(NioServerSocketChannel.class),
                             eventGroupConfig -> assertThat(eventGroupConfig.clazz()).isAssignableFrom(KQueueServerSocketChannel.class));

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -35,6 +35,7 @@ import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class KafkaProxyTest {
@@ -375,9 +376,9 @@ class KafkaProxyTest {
     }
 
     @Test
-    void shouldNotAllowShuttingDownOfAStoppedInstance() throws Exception {
+    void shouldAllowShuttingDownBeforeStartup() throws Exception {
         try (var proxy = new KafkaProxy(configParser, configParser.parseConfiguration(MINIMUM_VIABLE_CONFIG_YAML), Features.defaultFeatures())) {
-            assertThatThrownBy(proxy::shutdown).isInstanceOf(IllegalStateException.class).hasMessage("This proxy is not running");
+            assertThatCode(proxy::shutdown).doesNotThrowAnyException();
         }
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyConfig.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyConfig.java
@@ -8,12 +8,24 @@ package io.kroxylicious.proxy.internal.filter;
 
 import java.util.function.Consumer;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public final class FlakyConfig {
     private final String initializeExceptionMsg;
     private final String createExceptionMsg;
     private final String closeExceptionMsg;
     private final Consumer<FlakyConfig> onClose;
     private final Consumer<FlakyConfig> onInitialize;
+
+    @JsonCreator
+    public FlakyConfig(@JsonProperty("initializeExceptionMsg") String initializeExceptionMsg,
+                       @JsonProperty("createExceptionMsg") String createExceptionMsg,
+                       @JsonProperty("closeExceptionMsg") String closeExceptionMsg) {
+        this(initializeExceptionMsg, createExceptionMsg, closeExceptionMsg, c -> {
+        }, c -> {
+        });
+    }
 
     public FlakyConfig(String initializeExceptionMsg,
                        String createExceptionMsg,


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

One rough idea for how to lock down the state transitions. Introduces a transitionTo method which is sort of a declarative way to say "I want to transition to this state, keep retrying until either the transition is successful, or we are in a state that cannot transition to this state (could be because we are already in that state, or because it's no longer a valid transition)". We pass it a callback so that code can be executed if and only if a transition is made. We also pass in a function so that the caller can react to a non-transition.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
